### PR TITLE
add engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.4.0",
   "description": "Javascript Library for IOTA",
   "main": "./lib/iota.js",
+  "engines": {
+    "node": ">=6"
+  },
   "scripts": {
     "build": "gulp",
     "test": "mocha"


### PR DESCRIPTION
it makes sense to signify which versions of node.js this library supports. I went for 6 because that is the current LTS release.