### PR TITLE
Normalize trytes when decoding trytes to ascii

### DIFF
--- a/lib/utils/asciiToTrytes.js
+++ b/lib/utils/asciiToTrytes.js
@@ -93,7 +93,21 @@ function fromTrytes(inputTrytes) {
     return outputString;
 }
 
+/**
+ * This method normalizes trytes by appending '9'
+ * in case a tryte string length is odd.
+ *
+ * @param {string} inputTrytes
+ * @returns {string} A tryte with an even length.
+ */
+function normalizeTrytes(inputTrytes) {
+    if ( inputTrytes.length % 2 ) return normalizeTrytes(inputTrytes += '9')
+
+    return inputTrytes;
+}
+
 module.exports = {
     toTrytes: toTrytes,
-    fromTrytes: fromTrytes
+    fromTrytes: fromTrytes,
+    normalizeTrytes: normalizeTrytes
 }

--- a/lib/utils/asciiToTrytes.js
+++ b/lib/utils/asciiToTrytes.js
@@ -71,7 +71,7 @@ function fromTrytes(inputTrytes) {
     if ( typeof inputTrytes !== 'string' ) return null
 
     // If input length is odd, return null
-    if ( inputTrytes.length % 2 ) return null
+    if ( inputTrytes.length % 2 ) inputTrytes = normalizeTrytes(inputTrytes)
 
     var TRYTE_VALUES = "9ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     var outputString = "";

--- a/test/utils/utils.normalizeTrytes.js
+++ b/test/utils/utils.normalizeTrytes.js
@@ -1,0 +1,27 @@
+var chai = require('chai');
+var assert = chai.assert;
+var Utils = require('../../lib/utils/asciiToTrytes.js');
+
+describe('utils.normalizeTrytes', function() {
+
+    var tests = [
+        {
+            original: 'UYEEERFQYTPFA',
+            valid: 'UYEEERFQYTPFA9'
+        },
+        {
+            original: 'UYEEERFQYTPFA9',
+            valid: 'UYEEERFQYTPFA9'
+        }
+    ]
+
+    tests.forEach(function(test) {
+
+        it('should normalize tryte: ' + test.original, function() {
+
+            var normalizedTryte = Utils.normalizeTrytes(test.original);
+
+            assert.equal(normalizedTryte, test.valid);
+        });
+    })
+});


### PR DESCRIPTION
Found out the hard way that tryte string length should be even, wasn't able to decode the tag and message.
This method appends a '9' to trytes to make the string length even.