### PR TITLE
Add converter between Unicode character and trytes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ iota.api.getNodeInfo(function(error, success) {
     - **[categorizeTransfers](#categorizetransfers)**
     - **[toTrytes](#totrytes)**
     - **[fromTrytes](#fromtrytes)**
+    - **[unicodeToTrytes](#unicodeToTrytes)**
+    - **[unicodeFromTrytes](#unicodeFromTrytes)**
     - **[extractJson](#extractjson)**
     - **[validateSignatures](#validatesignatures)**
     - **[isBundle](#isbundle)**
@@ -703,6 +705,38 @@ Reverse of toTrytes.
 #### Input
 ```
 iota.utils.fromTrytes(trytes)
+```
+
+1. **`trytes`**: `String` Trytes you want to convert to string
+
+#### Returns
+`string` - string
+
+---
+
+### `unicodeToTrytes`
+
+Converts Unicode characters into trytes according to our encoding schema (read the source code for more info as to how it works). If you want to convert JSON data, stringify it first.
+
+#### Input
+```
+iota.utils.unicodeToTrytes(input)
+```
+
+1. **`input`**: `String` String you want to convert into trytes. All non-string values should be converted into strings first.
+
+#### Returns
+`string || null` - trytes, or null in case you provided an invalid string
+
+---
+
+### `unicodeFromTrytes`
+
+Reverse of unicodeToTrytes.
+
+#### Input
+```
+iota.utils.unicodeFromTrytes(trytes)
 ```
 
 1. **`trytes`**: `String` Trytes you want to convert to string

--- a/lib/utils/unicodeToTrytes.js
+++ b/lib/utils/unicodeToTrytes.js
@@ -1,0 +1,106 @@
+//
+//  Conversion of unicode encoded bytes to trytes.
+//  Input is a string (can be stringified JSON object), return value is Trytes
+//
+//  How the conversion works:
+//    One Unicode takes 2 Bytes, can be converted to four trytes.
+//    There are a total of 27 different tryte values: 9ABCDEFGHIJKLMNOPQRSTUVWXYZ
+//
+//    1. We get the decimal unicode value of an individual character
+//    2. From the decimal value, we then derive the four tryte values by basically calculating the tryte equivalent (e.g. 25615 === 19 + 3*27 + 8*27^2 + 1*27^3)
+//      a. The fourth tryte value is the floor integer of decimal value divide 27^3
+//      b. The third tryte value is the floor integer of (decimal value - fourth value * 27^3) divide 27^2
+//      c. The second tryte value is the floor integer of (decimal value - fourth value * 27^3 - third value * 27^2) divide 27
+//      d. The first tryte value is the reminder of decimal value modulo 27 (27 trytes)
+//    3. The four values returned from Step 2 are then input as indices into the available values list ('9ABCDEFGHIJKLMNOPQRSTUVWXYZ') to get the correct tryte value
+//
+//   EXAMPLES
+//      Lets say we want to convert the Unicode character "中".
+//        1. '中' has a decimal value of 20013.
+//        2. 20013 can be represented as 6 + 12 * 27 + 0 * 27^2 + 1 * 27^3. To make it simpler:
+//           a. Fourth value: 20013 / 27^3, then get the floor is 1. This is our fourth value.
+//           b. Third value: (20013 - 1 * 27^3) / 27^2, then get the floor is 0. This is our third value.
+//           c. Second value: (20013 - 1 * 27^3 - 0 * 27^2) / 27, then get the floor is 12. This is our second value.
+//           d. First value: 20013 modulo 27 is 6. This is now our first value
+//        3. Our two values are now 6, 12, 0 and 1. To get the tryte value now we simply insert it as indices into '9ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+//           a. The first tryte value is '9ABCDEFGHIJKLMNOPQRSTUVWXYZ'[6] === "F"
+//           b. The second tryte value is '9ABCDEFGHIJKLMNOPQRSTUVWXYZ'[12] === "L"
+//           c. The third tryte value is '9ABCDEFGHIJKLMNOPQRSTUVWXYZ'[0] === "9"
+//           b. The fourth tryte value is '9ABCDEFGHIJKLMNOPQRSTUVWXYZ'[1] === "A"
+//        Our tryte tetrad is "FL9A"
+//
+//      RESULT:
+//        The Unicode char "中" is represented as "FL9A" in trytes.
+//
+function unicodeToTrytes(input) {
+
+  // If input is not a string, return null
+  if ( typeof input !== 'string' ) return null
+
+  var TRYTE_VALUES = "9ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  var trytes = "";
+
+  for (var i = 0; i < input.length; i++) {
+    var char = input[i];
+    var unicodeValue = char.charCodeAt(0);
+
+    var fourthValue = Math.floor(
+      unicodeValue / Math.pow(27, 3)
+    )
+    var thirdValue = Math.floor(
+      (unicodeValue - fourthValue * Math.pow(27, 3)) / Math.pow(27, 2)
+    )
+    var secondValue = Math.floor(
+      (unicodeValue - fourthValue * Math.pow(27, 3) - thirdValue * Math.pow(27, 2)) / 27
+    )
+    var firstValue = unicodeValue % 27
+    var trytesValue = TRYTE_VALUES[firstValue] + TRYTE_VALUES[secondValue] + TRYTE_VALUES[thirdValue] + TRYTE_VALUES[fourthValue];
+
+    trytes += trytesValue;
+  }
+
+  return trytes;
+}
+
+
+//
+//  Trytes to bytes
+//  4 Trytes == 1 Unicode character
+//  We assume that the trytes are a JSON encoded object thus for our encoding:
+//    First character = {
+//    Last character = }
+//    Everything after that is 9's padding
+//
+function unicodeFromTrytes(inputTrytes) {
+
+  // If input is not a string, return null
+  if ( typeof inputTrytes !== 'string' ) return null
+
+  // If input length is not a multiple of 4, return null
+  if ( inputTrytes.length % 4 ) return null
+
+  var TRYTE_VALUES = "9ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  var outputString = "";
+
+  for (var i = 0; i < inputTrytes.length; i += 4) {
+    // get a trytes tetrad
+    var trytes = inputTrytes[i] + inputTrytes[i+1] + inputTrytes[i+2] + inputTrytes[i+3];
+
+    var firstValue = TRYTE_VALUES.indexOf(trytes[0]);
+    var secondValue = TRYTE_VALUES.indexOf(trytes[1]);
+    var thirdValue = TRYTE_VALUES.indexOf(trytes[2]);
+    var fourthValue = TRYTE_VALUES.indexOf(trytes[3])
+    var decimalValue = firstValue + secondValue * 27 + thirdValue * Math.pow(27, 2) + fourthValue * Math.pow(27, 3);
+
+    var character = String.fromCharCode(decimalValue);
+
+    outputString += character;
+  }
+
+  return outputString;
+}
+
+module.exports = {
+    unicodeToTrytes: unicodeToTrytes,
+    unicodeFromTrytes: unicodeFromTrytes
+}

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -6,6 +6,7 @@ var Converter       =   require("../crypto/converter/converter");
 var Signing         =   require("../crypto/signing/signing");
 var CryptoJS        =   require("crypto-js");
 var ascii           =   require("./asciiToTrytes");
+var unicode         =   require("./unicodeToTrytes");
 var extractJson     =   require("./extractJson");
 var BigNumber       =   require("bignumber.js");
 
@@ -465,6 +466,8 @@ module.exports = {
     categorizeTransfers : categorizeTransfers,
     toTrytes            : ascii.toTrytes,
     fromTrytes          : ascii.fromTrytes,
+    unicodeToTrytes     : unicode.unicodeToTrytes,
+    unicodeFromTrytes   : unicode.unicodeFromTrytes,
     extractJson         : extractJson,
     validateSignatures  : validateSignatures,
     isBundle            : isBundle

--- a/test/utils/utils.unicodeFromTrytes.js
+++ b/test/utils/utils.unicodeFromTrytes.js
@@ -41,6 +41,22 @@ describe('utils.unicodeFromTrytes', function() {
         {
             message: '你好',
             expected: true
+        },
+        {
+            message: 'こんにちは',
+            expected: true
+        },
+        {
+            message: '여보세요',
+            expected: true
+        },
+        {
+            message: 'Olá',
+            expected: true
+        },
+        {
+            message: 'Здравствуйте',
+            expected: true
         }
     ]
 

--- a/test/utils/utils.unicodeFromTrytes.js
+++ b/test/utils/utils.unicodeFromTrytes.js
@@ -1,0 +1,67 @@
+var chai = require('chai');
+var assert = chai.assert;
+var Utils = require('../../lib/utils/utils.js');
+
+
+describe('utils.unicodeFromTrytes', function() {
+
+    var tests = [
+        {
+            message: " ASDFDSAFDSAja9fd",
+            expected: true
+        },
+        {
+            message: "994239432",
+            expected: true
+        },
+        {
+            message: "{ 'a' : 'b', 'c': 'd', 'e': '#asdfd?$' }",
+            expected: true
+        },
+        {
+            message: "{ 'a' : 'b', 'c': {'nested': 'json', 'much': 'wow', 'array': [ true, false, 'yes' ] } }",
+            expected: true
+        },
+        {
+            message: 994239432,
+            expected: false
+        },
+        {
+            message: 'true',
+            expected: true
+        },
+        {
+            message: Array(9, 'yes', true),
+            expected: false
+        },
+        {
+            message: { 'a' : 'b' },
+            expected: false
+        },
+        {
+            message: '你好',
+            expected: true
+        }
+    ]
+
+    tests.forEach(function(test) {
+
+        it('should convert trytes to string and back. Test: ' + test.message + ' with result: ' + test.expected, function() {
+
+            var trytes = Utils.unicodeToTrytes(test.message);
+
+            var toString = Utils.unicodeFromTrytes(trytes);
+
+            if (test.expected) {
+
+                assert.strictEqual(toString, test.message);
+
+            } else {
+
+                assert.isNull(toString);
+
+            }
+        });
+
+    })
+});

--- a/test/utils/utils.unicodeToTrytes.js
+++ b/test/utils/utils.unicodeToTrytes.js
@@ -1,0 +1,76 @@
+var chai = require('chai');
+var assert = chai.assert;
+var Utils = require('../../lib/utils/utils.js');
+
+
+describe('utils.toTrytes', function() {
+
+    var tests = [
+        {
+            message: " ΣASDFDSAFDSAja9fd",
+            expected: true
+        },
+        {
+            message: " ASDFDSAFDSAja9fd",
+            expected: true
+        },
+        {
+            message: "994239432",
+            expected: true
+        },
+        {
+            message: "{ 'a' : 'b', 'c': 'd', 'e': '#asdfd?$' }",
+            expected: true
+        },
+        {
+            message: "{ 'a' : 'b', 'c': {'nested': 'json', 'much': 'wow', 'array': [ true, false, 'yes' ] } }",
+            expected: true
+        },
+        {
+            message: "{ 'a' : 'b', 'c': {'nested': 'json', 'much': 'wow', 'array': [ true, false, 'yes' ] } }",
+            expected: true
+        },
+        {
+            message: "{'message': 'IOTA is a revolutionary new transactional settlement and data transfer layer for the Internet of Things. It's based on a new distributed ledger, the Tangle, which overcomes the inefficiencies of current Blockchain designs and introduces a new way of reaching consensus in a decentralized peer-to-peer system. For the first time ever, through IOTA people can transfer money without any fees. This means that even infinitesimally small nanopayments can be made through IOTA. IOTA is the missing puzzle piece for the Machine Economy to fully emerge and reach its desired potential. We envision IOTA to be the public, permissionless backbone for the Internet of Things that enables true interoperability between all devices. Tangle: A directed acyclic graph (DAG) as a distributed ledger which stores all transaction data of the IOTA network. It is a Blockchain without the blocks and the chain (so is it really a Blockchain?). The Tangle is the first distributed ledger to achieve scalability, no fee transactions, data integrity and transmission as well as quantum-computing protection. Contrary to today's Blockchains, consensus is no-longer decoupled but instead an intrinsic part of the system, leading to a completely decentralized and self-regulating peer-to-peer network. All IOTA\'s which will ever exist have been created with the genesis transaction. This means that the total supply of IOTA\'s will always stay the same and you cannot mine IOTA\'s. Therefore keep in mind, if you do Proof of Work in IOTA you are not generating new IOTA tokens, you\'re simply verifying other transactions.'}",
+            expected: true
+        },
+        {
+            message: 994239432,
+            expected: false
+        },
+        {
+            message: true,
+            expected: false
+        },
+        {
+            message: Array(9, 'yes', true),
+            expected: false
+        },
+        {
+            message: { 'a' : 'b' },
+            expected: false
+        },
+        {
+            message: "你好",
+            expected: true
+        }
+    ]
+
+    tests.forEach(function(test) {
+
+        it('should convert: ' + test.message + ' to trytes with result: ' + test.expected, function() {
+
+            var trytes = Utils.unicodeToTrytes(test.message);
+
+            if (test.expected) {
+
+                assert.isNotNull(trytes);
+
+            } else {
+
+                assert.isNull(trytes);
+            }
+        });
+
+    })
+});

--- a/test/utils/utils.unicodeToTrytes.js
+++ b/test/utils/utils.unicodeToTrytes.js
@@ -53,6 +53,22 @@ describe('utils.toTrytes', function() {
         {
             message: "你好",
             expected: true
+        },
+        {
+            message: 'こんにちは',
+            expected: true
+        },
+        {
+            message: '여보세요',
+            expected: true
+        },
+        {
+            message: 'Olá',
+            expected: true
+        },
+        {
+            message: 'Здравствуйте',
+            expected: true
         }
     ]
 


### PR DESCRIPTION
## Why this change:
Currently the `utils.fromTrytes` and `utils.toTrytes` do not support Unicode, 
As more and more people around the world use tangle, it's necessary for them to encode their message in non-english lang.

## What changes:
1. It's not a good idea to just replace the current ascii converter, since there are already messages encoded with this converter.
2. Add unicode converter
3. Add test for this converter
4. Add readme.

## More work:
`utils.extractJson` with unicode. Will do it in another PR.
