### PR TITLE
Added basic auth (username & password) support in provider url

### DIFF
--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -38,7 +38,15 @@ makeRequest.prototype.setProvider = function(provider) {
 makeRequest.prototype.open = function() {
 
     var request = xmlHttpRequest();
-    request.open('POST', this.provider, true);
+    var urlParts = require('url').parse(this.provider);
+    if(urlParts.auth){
+    	authParts = urlParts.auth.split(':');
+    	request.withCredentials = true;
+    	request.open('POST', this.provider, true, authParts[0], authParts[1]);
+    } else {
+    	request.open('POST', this.provider, true);
+    }
+    
     request.setRequestHeader('Content-Type','application/json');
     request.setRequestHeader('X-IOTA-API-Version', '1');
 


### PR DESCRIPTION
Merging this will allow users to hit endpoints behind basic auth in the wallet, for instance if we wanted to create private access to API or a http proxy.

Alternative to this would be something like https://github.com/iotaledger/iota.lib.js/pull/35

Other alternative is for xmlhttprequest to respect the url structure as well

I believe this solution may be more robust than that as it will automatically take into account user:pass@host in url according to http standards. It will automatically start using credentials provided this way in the wallet without any other change to wallet code.
