### PR TITLE
Fix bundle query in getBundlesFromAddresses

### DIFF
--- a/packages/core/src/createGetBundlesFromAddresses.ts
+++ b/packages/core/src/createGetBundlesFromAddresses.ts
@@ -26,7 +26,9 @@ export const createGetBundlesFromAddresses = (provider: Provider, caller?: strin
                 // 2. Get all transactions by bundle hashes
                 .then(transactions =>
                     findTransactionObjects({
-                        bundles: transactions.filter(tx => tx.currentIndex === 0).map(tx => tx.bundle),
+                        bundles: transactions
+                            .map(tx => tx.bundle)
+                            .filter((bundle, i, bundles) => bundles.indexOf(bundle) === i),
                     })
                 )
 

--- a/packages/core/test/integration/nocks/findTransactions.ts
+++ b/packages/core/test/integration/nocks/findTransactions.ts
@@ -92,7 +92,7 @@ nock('http://localhost:14265', headers)
     .persist()
     .post('/', {
         command: IRICommand.FIND_TRANSACTIONS,
-        bundles: ['9'.repeat(81), '9'.repeat(81)],
+        bundles: ['9'.repeat(81)],
     })
     .reply(200, findTransactionsResponse)
 


### PR DESCRIPTION
# Description

Fixes `bundles` query in `getBundlesFromAddresses`. This issue propagated in `getAccountData` & `getTransfers`, resulting to missing txs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Fixed integration test


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes