### PR TITLE
Input objects: Add balance validation & set default security to 2

### DIFF
--- a/packages/core/src/createPrepareTransfers.ts
+++ b/packages/core/src/createPrepareTransfers.ts
@@ -34,6 +34,7 @@ const HASH_LENGTH = 81
 const SIGNATURE_MESSAGE_FRAGMENT_LENGTH = 2187
 const KEY_FRAGMENT_LENGTH = 6561
 const NULL_HASH_TRYTES = '9'.repeat(HASH_LENGTH)
+const SECURITY_LEVEL = 2
 
 export interface PrepareTransfersOptions {
     readonly inputs: ReadonlyArray<Address>
@@ -350,7 +351,7 @@ export const addSignatures = (props: PrepareTransfersProps): PrepareTransfersPro
         transactions: addTrytes(
             transactions,
             inputs.reduce((acc: ReadonlyArray<Trytes>, { keyIndex, security }) => {
-                const keyTrits = key(subseed(trits(seed), keyIndex), security)
+                const keyTrits = key(subseed(trits(seed), keyIndex), security || SECURITY_LEVEL)
 
                 return acc.concat(
                     Array(security)

--- a/packages/core/test/integration/prepareTransfers.test.ts
+++ b/packages/core/test/integration/prepareTransfers.test.ts
@@ -12,13 +12,13 @@ const inputs: ReadonlyArray<any> = [
         address: 'FJHSSHBZTAKQNDTIKJYCZBOZDGSZANCZSWCNWUOCZXFADNOQSYAHEJPXRLOVPNOQFQXXGEGVDGICLMOXX',
         keyIndex: 0,
         security: 2,
-        balance: '3',
+        balance: 3,
     },
     {
         address: '9DZXPFSVCSSWXXQPFMWLGFKPBAFTHYMKMZCPFHBVHXPFNJEIJIEEPKXAUBKBNNLIKWHJIYQDFWQVELOCB',
         keyIndex: 1,
         security: 2,
-        balance: '4',
+        balance: 4,
     },
 ]
 

--- a/packages/guards.ts
+++ b/packages/guards.ts
@@ -79,11 +79,12 @@ export const isSecurityLevel = (security: any): security is number => Number.isI
  *
  * @return {boolean}
  */
-export const isInput = (address: any): address is Address =>
-    isHash(address.address) &&
-    isSecurityLevel(address.security) &&
-    Number.isInteger(address.keyIndex) &&
-    address.keyIndex >= 0
+export const isInput = (input: any): input is Address =>
+    isHash(input.address) &&
+    (typeof input.security === 'undefined' || isSecurityLevel(input.security)) &&
+    (typeof input.balance === 'undefined' || (Number.isInteger(input.balance) && input.balance > 0)) &&
+    Number.isInteger(input.keyIndex) &&
+    input.keyIndex >= 0
 
 /**
  * Checks that input is valid tag trytes.

--- a/packages/types.ts
+++ b/packages/types.ts
@@ -15,7 +15,7 @@ export interface Balance {
 export interface Address extends Balance {
     readonly address: Hash
     readonly keyIndex: number
-    readonly security: number
+    readonly security?: number
 }
 
 export const makeAddress = (address: Hash, balance: number, keyIndex: number, security: number): Address => ({

--- a/packages/validators/test/isInput.test.ts
+++ b/packages/validators/test/isInput.test.ts
@@ -1,0 +1,87 @@
+import test from 'ava'
+import { isInput } from '../src'
+
+test('isInput()', t => {
+    const address = 'JALLWDUOSTSJVL9EEHKW9YQFPBVBJAGLNKRVGSQZCGHQWEMIIILJMTHVAGVDXJVZMBAMOZTSBQNRVNLLS'
+    const validInput = {
+        address,
+        security: 2,
+        keyIndex: 0,
+        balance: 10,
+    }
+
+    t.is(isInput(validInput), true, 'isInput returns true for valid input')
+
+    t.is(
+        isInput({
+            address,
+            keyIndex: 0,
+            balance: 10,
+        }),
+        true,
+        'isInput returns true for valid input without security level'
+    )
+
+    t.is(
+        isInput({
+            address,
+            keyIndex: 0,
+        }),
+        true,
+        'isInput returns true for valid input without balance'
+    )
+
+    t.is(
+        isInput({
+            ...validInput,
+            address: 'dsafas',
+        }),
+        false,
+        'isInput returns false for input with invalid address'
+    )
+
+    t.is(
+        isInput({
+            ...validInput,
+            address: undefined,
+        }),
+        false,
+        'isInput returns false for input without address'
+    )
+
+    t.is(
+        isInput({
+            ...validInput,
+            security: -1.5,
+        }),
+        false,
+        'isInput returns false for input with invalid security'
+    )
+
+    t.is(
+        isInput({
+            ...validInput,
+            keyIndex: -1,
+        }),
+        false,
+        'isInput returns false for input with invalid keyIndex'
+    )
+
+    t.is(
+        isInput({
+            ...validInput,
+            keyIndex: undefined,
+        }),
+        false,
+        'isInput returns false for input without keyIndex'
+    )
+
+    t.is(
+        isInput({
+            ...validInput,
+            balance: -10,
+        }),
+        false,
+        'isInput returns false for invalid balance'
+    )
+})


### PR DESCRIPTION
# Description

- Adds validation for `input.balance`
- Makes `input.security` optional and sets default value to `2`

Fixes #277 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] [Unit tests](https://github.com/chrisdukakis/iota.js/blob/26b46e3dd48dff11f7dd52cc2f7d0265ce841911/packages/validators/test/isInput.test.ts)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes