### PR TITLE
filter inputs with zero balance

### DIFF
--- a/packages/core/src/createGetInputs.ts
+++ b/packages/core/src/createGetInputs.ts
@@ -133,7 +133,9 @@ export const createInputsObject = (
     start: number,
     security: number
 ): Inputs => {
-    const inputs = addresses.map((address, i) => makeAddress(address, balances[i], start + i, security))
+    const inputs = addresses
+        .map((address, i) => makeAddress(address, balances[i], start + i, security))
+        .filter(address => address.balance > 0)
     const totalBalance = inputs.reduce((acc, addr) => (acc += addr.balance), 0)
     return { inputs, totalBalance }
 }

--- a/packages/core/test/integration/getAccountData.test.ts
+++ b/packages/core/test/integration/getAccountData.test.ts
@@ -26,12 +26,6 @@ const accountData: AccountData = {
     addresses: accountAddresses,
     inputs: [
         {
-            address: getBalancesCommand.addresses[1],
-            balance: balances[1],
-            keyIndex: 1,
-            security: 2,
-        },
-        {
             address: getBalancesCommand.addresses[2],
             balance: balances[2],
             keyIndex: 2,
@@ -49,7 +43,7 @@ const accountData: AccountData = {
             ),
         []
     ),
-    balance: 10,
+    balance: 1,
 }
 
 test('getAccountData() resolves to correct account data', async t => {

--- a/packages/core/test/integration/getInputs.test.ts
+++ b/packages/core/test/integration/getInputs.test.ts
@@ -26,23 +26,13 @@ const inputs: Inputs = {
             security: 2,
         },
         {
-            address: getBalancesCommand.addresses[1],
-            balance: balances[1],
-            keyIndex: 1,
+            address: getBalancesCommand.addresses[2],
+            balance: balances[2],
+            keyIndex: 2,
             security: 2,
         },
     ],
-    totalBalance: balances[0] + balances[1],
-}
-
-const allInputs: Inputs = {
-    inputs: [...inputs.inputs].concat({
-        address: getBalancesCommand.addresses[2],
-        balance: balances[2],
-        keyIndex: 2,
-        security: 2,
-    }),
-    totalBalance: inputs.totalBalance + balances[2],
+    totalBalance: balances[0] + balances[2],
 }
 
 test('inputsToAddressOptions() translates getInputs() options to compatible getNewAddress() options', t => {
@@ -84,7 +74,7 @@ test('inputsToAddressOptions() translates getInputs() options to compatible getN
 test('createInputsObject() aggregates addresses and balances', t => {
     t.deepEqual(
         createInputsObject(getBalancesCommand.addresses, balances, 0, 2),
-        allInputs,
+        inputs,
         'createInputsObject() should aggregate addresses and balances correctly'
     )
 })

--- a/packages/core/test/integration/nocks/getBalances.ts
+++ b/packages/core/test/integration/nocks/getBalances.ts
@@ -12,8 +12,8 @@ export const getBalancesCommand: GetBalancesCommand = {
     threshold: 100,
 }
 
-export const balancesResponse: Balances = {
-    balances: [99, 1, 9],
+export const balancesResponse = {
+    balances: [99, 0, 1],
     milestone: 'M'.repeat(81),
     milestoneIndex: 1,
 }
@@ -34,5 +34,5 @@ nock('http://localhost:14265', headers)
     })
     .reply(200, {
         ...balancesResponse,
-        balances: ['1', '9'],
+        balances: ['0', '1'],
     })


### PR DESCRIPTION
# Description

Fixes `getInputs` to filter out addresses without balance.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Updated integration tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes