### PR TITLE
fix remainder address start index

### DIFF
--- a/packages/core/src/createPrepareTransfers.ts
+++ b/packages/core/src/createPrepareTransfers.ts
@@ -322,7 +322,7 @@ export const createAddRemainder = (provider?: Provider) => {
 }
 
 export const getRemainderAddressStartIndex = (inputs: ReadonlyArray<Address>): number =>
-    [...inputs].sort((a, b) => a.keyIndex - b.keyIndex)[0].keyIndex
+    [...inputs].sort((a, b) => b.keyIndex - a.keyIndex)[0].keyIndex + 1
 
 export const verifyNotSendingToInputs = (props: PrepareTransfersProps): PrepareTransfersProps => {
     const { transactions } = props

--- a/packages/core/test/integration/prepareTransfers.test.ts
+++ b/packages/core/test/integration/prepareTransfers.test.ts
@@ -1,9 +1,10 @@
-import test from 'ava'
-import { createHttpClient } from '@iota/http-client'
 import { addChecksum } from '@iota/checksum'
-import { createPrepareTransfers } from '../../src'
-import { Transfer, Trytes } from '../../../types'
+import { createHttpClient } from '@iota/http-client'
 import { addresses, trytes as expected } from '@iota/samples'
+import test from 'ava'
+import { Transfer, Trytes } from '../../../types'
+import { createPrepareTransfers } from '../../src'
+import { getRemainderAddressStartIndex } from '../../src/createPrepareTransfers'
 
 import './nocks/prepareTransfers'
 
@@ -21,6 +22,8 @@ const inputs: ReadonlyArray<any> = [
         balance: 4,
     },
 ]
+
+test('getRemainderAddressStartIndex', t => t.is(getRemainderAddressStartIndex(inputs), 2))
 
 const transfers: ReadonlyArray<Transfer> = [
     {


### PR DESCRIPTION
# Description

Fixes a minor issue in selection of initial index to get new remainder address. This improves speed of `prepareTransfers`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added [unit test](https://github.com/iotaledger/iota.js/compare/next...chrisdukakis:fix/remainder-start-index?expand=1#diff-f600f2e516a7e244fcd4e93b19670e05) for `getRemainderAddressStartIndex`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes