### PR TITLE
Update docs to clarify necessity of storing trytes before broadcasting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,16 @@ const depth = 3
 // Minimum value on mainnet & spamnet is `14`, `9` on devnet and other testnets.
 const minWeightMagnitude = 14
 
+// Prepare a bundle and signs it
 iota.prepareTransfers(seed, transfers)
-    .then(trytes => iota.sendTrytes(trytes, depth, minWeightMagnitude))
+    .then(trytes => {
+        // Persist trytes locally before sending to network.
+        // This allows for reattachments and prevents key reuse if trytes can't
+        // be recovered by querying the network after broadcasting.
+
+        // Does tip selection, attaches to tangle by doing PoW and broadcasts.
+        return iota.sendTrytes(trytes, depth, minWeightMagnitude)
+    })
     .then(bundle => {
         console.log(`Published transaction with tail hash: ${bundle[0].hash}`)
         console.log(`Bundle: ${bundle}`)

--- a/api_reference.md
+++ b/api_reference.md
@@ -488,6 +488,9 @@ or remote [`PoWbox`](https://powbox.devnet.iota.org/).
 `trunkTransaction` and `branchTransaction` hashes are given by
 [`getTransactionToApprove`](#module_core.getTransactionsToApprove).
 
+**Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
+that reattachment is possible, until your bundle has been included.
+
 **Example**  
 ```js
 getTransactionsToApprove(depth)
@@ -530,7 +533,7 @@ particularly in the case of large bundles.
 
 **Example**  
 ```js
-broadcastTransactions(tailHash)
+broadcastBundle(tailHash)
   .then(transactions => {
      // ...
   })
@@ -569,7 +572,7 @@ Tip selection and Proof-of-Work must be done first, by calling
 
 You may use this method to increase odds of effective transaction propagation.
 
-Persist the transaction trytes in local storage **before** calling this command for first time, to ensure
+**Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
 that reattachment is possible, until your bundle has been included.
 
 **Example**  
@@ -1348,6 +1351,9 @@ adding remainder and signing. It can be used to generate and sign bundles either
 For offline usage, please see [`createPrepareTransfers`](#module_core.createPrepareTransfers)
 which creates a `prepareTransfers` without a network provider.
 
+**Note:** After calling this method, persist the returned transaction trytes in local storage. Only then you should broadcast to netowrk.
+This will allow for reattachments and prevent key reuse if trytes can't be recovered by querying the netowrk after broadcasting.
+
 <a name="module_core.createPromoteTransaction"></a>
 
 ### *core*.createPromoteTransaction(provider, [attachFn])
@@ -1481,10 +1487,19 @@ replayBundle(tail)
 [Attaches to tanlge](#module_core.attachToTangle), [stores](#module_core.storeTransactions)
 and [broadcasts](#module_core.broadcastTransactions) a list of transaction trytes.
 
+**Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
+that reattachment is possible, until your bundle has been included.
+
 **Example**  
 ```js
 prepareTransfers(seed, transfers)
-  .then(trytes => sendTrytes(trytes, depth, minWeightMagnitude))
+  .then(trytes => {
+    // Persist trytes locally before sending to network.
+    // This allows for reattachments and prevents key reuse if trytes can't
+    // be recovered by querying the network after broadcasting.
+
+    return iota.sendTrytes(trytes, depth, minWeightMagnitude)
+  })
   .then(transactions => {
     // ...
   })
@@ -1518,7 +1533,7 @@ Stores and broadcasts a list of _attached_ transaction trytes by calling
 [`storeTransactions`](#module_core.storeTransactions) and
 [`broadcastTransactions`](#module_core.broadcastTransactions).
 
-Note: Persist the transaction trytes in local storage **before** calling this command, to ensure
+**Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
 that reattachment is possible, until your bundle has been included.
 
 Any transactions stored with this command will eventaully be erased, as a result of a snapshot.
@@ -1552,8 +1567,8 @@ Tip selection and Proof-of-Work must be done first, by calling
 [`attachToTangle`](#module_core.attachToTangle) or an equivalent attach method or remote
 [`PoWbox`](https://powbox.devnet.iota.org/).
 
-Persist the transaction trytes in local storage **before** calling this command, to ensure
-reattachment is possible, until your bundle has been included.
+**Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
+that reattachment is possible, until your bundle has been included.
 
 Any transactions stored with this command will eventaully be erased, as a result of a snapshot.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -245,6 +245,9 @@ or remote [`PoWbox`](https://powbox.devnet.iota.org/).
 `trunkTransaction` and `branchTransaction` hashes are given by
 [`getTransactionToApprove`](#module_core.getTransactionsToApprove).
 
+**Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
+that reattachment is possible, until your bundle has been included.
+
 **Example**  
 ```js
 getTransactionsToApprove(depth)
@@ -287,7 +290,7 @@ particularly in the case of large bundles.
 
 **Example**  
 ```js
-broadcastTransactions(tailHash)
+broadcastBundle(tailHash)
   .then(transactions => {
      // ...
   })
@@ -326,7 +329,7 @@ Tip selection and Proof-of-Work must be done first, by calling
 
 You may use this method to increase odds of effective transaction propagation.
 
-Persist the transaction trytes in local storage **before** calling this command for first time, to ensure
+**Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
 that reattachment is possible, until your bundle has been included.
 
 **Example**  
@@ -1105,6 +1108,9 @@ adding remainder and signing. It can be used to generate and sign bundles either
 For offline usage, please see [`createPrepareTransfers`](#module_core.createPrepareTransfers)
 which creates a `prepareTransfers` without a network provider.
 
+**Note:** After calling this method, persist the returned transaction trytes in local storage. Only then you should broadcast to netowrk.
+This will allow for reattachments and prevent key reuse if trytes can't be recovered by querying the netowrk after broadcasting.
+
 <a name="module_core.createPromoteTransaction"></a>
 
 ### *core*.createPromoteTransaction(provider, [attachFn])
@@ -1238,10 +1244,19 @@ replayBundle(tail)
 [Attaches to tanlge](#module_core.attachToTangle), [stores](#module_core.storeTransactions)
 and [broadcasts](#module_core.broadcastTransactions) a list of transaction trytes.
 
+**Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
+that reattachment is possible, until your bundle has been included.
+
 **Example**  
 ```js
 prepareTransfers(seed, transfers)
-  .then(trytes => sendTrytes(trytes, depth, minWeightMagnitude))
+  .then(trytes => {
+     // Persist trytes locally before sending to network.
+     // This allows for reattachments and prevents key reuse if trytes can't
+     // be recovered by querying the network after broadcasting.
+
+     return iota.sendTrytes(trytes, depth, minWeightMagnitude)
+  })
   .then(transactions => {
     // ...
   })
@@ -1275,7 +1290,7 @@ Stores and broadcasts a list of _attached_ transaction trytes by calling
 [`storeTransactions`](#module_core.storeTransactions) and
 [`broadcastTransactions`](#module_core.broadcastTransactions).
 
-Note: Persist the transaction trytes in local storage **before** calling this command, to ensure
+**Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
 that reattachment is possible, until your bundle has been included.
 
 Any transactions stored with this command will eventaully be erased, as a result of a snapshot.
@@ -1309,8 +1324,8 @@ Tip selection and Proof-of-Work must be done first, by calling
 [`attachToTangle`](#module_core.attachToTangle) or an equivalent attach method or remote
 [`PoWbox`](https://powbox.devnet.iota.org/).
 
-Persist the transaction trytes in local storage **before** calling this command, to ensure
-reattachment is possible, until your bundle has been included.
+**Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
+that reattachment is possible, until your bundle has been included.
 
 Any transactions stored with this command will eventaully be erased, as a result of a snapshot.
 

--- a/packages/core/src/createAttachToTangle.ts
+++ b/packages/core/src/createAttachToTangle.ts
@@ -41,6 +41,9 @@ export const createAttachToTangle = ({ send }: Provider): AttachToTangle => {
      * `trunkTransaction` and `branchTransaction` hashes are given by
      * {@link #module_core.getTransactionsToApprove `getTransactionToApprove`}.
      *
+     * **Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
+     * that reattachment is possible, until your bundle has been included.
+     *
      * @example
      *
      * ```js

--- a/packages/core/src/createBroadcastBundle.ts
+++ b/packages/core/src/createBroadcastBundle.ts
@@ -26,7 +26,7 @@ export const createBroadcastBundle = (provider: Provider) => {
      * @example
      *
      * ```js
-     * broadcastTransactions(tailHash)
+     * broadcastBundle(tailHash)
      *   .then(transactions => {
      *      // ...
      *   })

--- a/packages/core/src/createBroadcastTransactions.ts
+++ b/packages/core/src/createBroadcastTransactions.ts
@@ -30,7 +30,7 @@ export const createBroadcastTransactions = ({ send }: Provider) =>
      *
      * You may use this method to increase odds of effective transaction propagation.
      *
-     * Persist the transaction trytes in local storage **before** calling this command for first time, to ensure
+     * **Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
      * that reattachment is possible, until your bundle has been included.
      *
      * @example

--- a/packages/core/src/createPrepareTransfers.ts
+++ b/packages/core/src/createPrepareTransfers.ts
@@ -94,6 +94,9 @@ export const createPrepareTransfers = (provider?: Provider, now: () => number = 
      * For offline usage, please see [`createPrepareTransfers`]{@link #module_core.createPrepareTransfers}
      * which creates a `prepareTransfers` without a network provider.
      *
+     * **Note:** After calling this method, persist the returned transaction trytes in local storage. Only then you should broadcast to netowrk.
+     * This will allow for reattachments and prevent key reuse if trytes can't be recovered by querying the netowrk after broadcasting.
+     *
      * @method prepareTransfers
      *
      * @memberof module:core

--- a/packages/core/src/createSendTrytes.ts
+++ b/packages/core/src/createSendTrytes.ts
@@ -23,10 +23,19 @@ export const createSendTrytes = (provider: Provider, attachFn?: AttachToTangle) 
      * [Attaches to tanlge]{@link #module_core.attachToTangle}, [stores]{@link #module_core.storeTransactions}
      * and [broadcasts]{@link #module_core.broadcastTransactions} a list of transaction trytes.
      *
+     * **Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
+     * that reattachment is possible, until your bundle has been included.
+     *
      * @example
      * ```js
      * prepareTransfers(seed, transfers)
-     *   .then(trytes => sendTrytes(trytes, depth, minWeightMagnitude))
+     *   .then(trytes => {
+     *      // Persist trytes locally before sending to network.
+     *      // This allows for reattachments and prevents key reuse if trytes can't
+     *      // be recovered by querying the network after broadcasting.
+     *
+     *      return iota.sendTrytes(trytes, depth, minWeightMagnitude)
+     *   })
      *   .then(transactions => {
      *     // ...
      *   })

--- a/packages/core/src/createStoreAndBroadcast.ts
+++ b/packages/core/src/createStoreAndBroadcast.ts
@@ -20,7 +20,7 @@ export const createStoreAndBroadcast = (provider: Provider) => {
      * [`storeTransactions`]{@link #module_core.storeTransactions} and
      * [`broadcastTransactions`]{@link #module_core.broadcastTransactions}.
      *
-     * Note: Persist the transaction trytes in local storage **before** calling this command, to ensure
+     * **Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
      * that reattachment is possible, until your bundle has been included.
      *
      * Any transactions stored with this command will eventaully be erased, as a result of a snapshot.

--- a/packages/core/src/createStoreTransactions.ts
+++ b/packages/core/src/createStoreTransactions.ts
@@ -28,8 +28,8 @@ export const createStoreTransactions = ({ send }: Provider) =>
      * [`attachToTangle`]{@link #module_core.attachToTangle} or an equivalent attach method or remote
      * [`PoWbox`](https://powbox.devnet.iota.org/).
      *
-     * Persist the transaction trytes in local storage **before** calling this command, to ensure
-     * reattachment is possible, until your bundle has been included.
+     * **Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
+     * that reattachment is possible, until your bundle has been included.
      *
      * Any transactions stored with this command will eventaully be erased, as a result of a snapshot.
      *


### PR DESCRIPTION
# Description

Clarifies that is required to store transaction trytes before broadcasting to network.

## Type of change

- [x] Documentation Fix

# How Has This Been Tested?

- [x] Auto-generated docs

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes