### PR TITLE
fix: parsing of json encoded request errors

### DIFF
--- a/packages/http-client/src/request.ts
+++ b/packages/http-client/src/request.ts
@@ -39,9 +39,22 @@ export const send = <C extends BaseCommand, R = any>(
             'X-IOTA-API-Version': apiVersion.toString(),
         },
         body: JSON.stringify(command),
-    })
-        .then(res => (res.ok ? res.json() : requestError(res.statusText)))
-        .then(json => (json.error || json.exception ? requestError(json.error || json.exception) : json))
+    }).then(res =>
+        res
+            .json()
+            .then(
+                json =>
+                    res.ok
+                        ? json
+                        : requestError(json.error || json.exception ? json.error || json.exception : res.statusText)
+            )
+            .catch(error => {
+                if (!res.ok && error.type === 'invalid-json') {
+                    return requestError(res.statusText)
+                }
+                throw error
+            })
+    )
 
 /**
  * Sends a batched http request to a specified host

--- a/packages/http-client/test/send.test.ts
+++ b/packages/http-client/test/send.test.ts
@@ -53,3 +53,27 @@ test('send() returns correct error message for bad request.', t => {
         t.is(error, 'Request error: Bad Request', 'httpClient.send() should throw correct error for bad request.')
     })
 })
+
+const invalidGetTransactionsToApproveCommand = {
+    command: IRICommand.GET_TRANSACTIONS_TO_APPROVE,
+    depth: 42000,
+}
+const invalidGetTransactionsToApproveResponse = {
+    error: 'Invalid depth input',
+    duration: 0,
+}
+
+export const badSendJSONResponseNock = nock('http://localhost:24265', headers(API_VERSION))
+    .persist()
+    .post('/', invalidGetTransactionsToApproveCommand)
+    .reply(400, invalidGetTransactionsToApproveResponse)
+
+test('send() parses and returns json encoded error of bad request.', t => {
+    return send(invalidGetTransactionsToApproveCommand).catch(error => {
+        t.is(
+            error,
+            `Request error: ${invalidGetTransactionsToApproveResponse.error}`,
+            'httpClient.send() should parse and return json encoded error of bad request.'
+        )
+    })
+})

--- a/packages/http-client/test/send.test.ts
+++ b/packages/http-client/test/send.test.ts
@@ -77,3 +77,18 @@ test('send() parses and returns json encoded error of bad request.', t => {
         )
     })
 })
+
+const invalidGetTransactionsToApproveCommandB = {
+    command: IRICommand.GET_TRANSACTIONS_TO_APPROVE,
+    depth: 42001,
+}
+export const badSendInvalidJSONResponseNock = nock('http://localhost:24265', headers(API_VERSION))
+    .persist()
+    .post('/', invalidGetTransactionsToApproveCommandB)
+    .reply(400, 'Invalid json')
+
+test('send() ignores invalid json of bad requests.', t => {
+    return send(invalidGetTransactionsToApproveCommandB).catch(error => {
+        t.is(error, 'Request error: Bad Request', 'httpClient.send() should ignore invalid json of bad requests.')
+    })
+})


### PR DESCRIPTION
# Description

This PR parses and returns JSON encoded errors of bad requests. A general `"Bad request"` error was displayed before this change, instead of specific error messages returned by IRI.
Perhaps we could return the JSON object as is, and not return the error field as string only... For now just returning `error` field seems fine I think...

Fixes #303 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added  [unit test](https://github.com/iotaledger/iota.js/pull/304/files#diff-ef9d94c92e701c315d340177f32d94ddR71) for parsing json encoded errors.
- [x] Added [unit test](https://github.com/iotaledger/iota.js/pull/304/files#diff-ef9d94c92e701c315d340177f32d94ddR90) for ignoring invalid json.
- [x] CI should pass.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes