### PR TITLE
fix: API return type

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,12 +1,13 @@
 # @iota/core
 
 Core functionality to interact with the IOTA network. Includes methods for:
-- Generating addresses
-- Creating, attaching and broadcasting transactions
-- Querying for transactions
-- Monitoring balances
-- Monitoring inclusion states and consistency of transactions
-- Promoting and reattaching pending transactions
+
+-   Generating addresses
+-   Creating, attaching and broadcasting transactions
+-   Querying for transactions
+-   Monitoring balances
+-   Monitoring inclusion states and consistency of transactions
+-   Promoting and reattaching pending transactions
 
 ## Installation
 
@@ -18,170 +19,171 @@ npm install @iota/core
 
 or using [yarn](https://yarnpkg.com/):
 
-``` yarn
+```yarn
 yarn add @iota/core
 ```
 
 ## API Reference
 
-    
-* [core](#module_core)
+-   [core](#module_core)
 
-    * [.composeApi([settings])](#module_core.composeApi)
+    -   [.composeApi([settings])](#module_core.composeApi)
 
-    * [.createAddNeighbors(provider)](#module_core.createAddNeighbors)
+    -   [.createAddNeighbors(provider)](#module_core.createAddNeighbors)
 
-    * [.addNeighbors(uris, [callback])](#module_core.addNeighbors)
+    -   [.addNeighbors(uris, [callback])](#module_core.addNeighbors)
 
-    * [.createAttachToTangle(provider)](#module_core.createAttachToTangle)
+    -   [.createAttachToTangle(provider)](#module_core.createAttachToTangle)
 
-    * [.attachToTangle(trunkTransaction, branchTransaction, minWeightMagnitude, trytes, [callback])](#module_core.attachToTangle)
+    -   [.attachToTangle(trunkTransaction, branchTransaction, minWeightMagnitude, trytes, [callback])](#module_core.attachToTangle)
 
-    * [.createBroadcastBundle(provider)](#module_core.createBroadcastBundle)
+    -   [.createBroadcastBundle(provider)](#module_core.createBroadcastBundle)
 
-    * [.broadcastBundle(tailTransactionHash, [callback])](#module_core.broadcastBundle)
+    -   [.broadcastBundle(tailTransactionHash, [callback])](#module_core.broadcastBundle)
 
-    * [.createBroadcastTransactions(provider)](#module_core.createBroadcastTransactions)
+    -   [.createBroadcastTransactions(provider)](#module_core.createBroadcastTransactions)
 
-    * [.broadcastTransactions(trytes, [callback])](#module_core.broadcastTransactions)
+    -   [.broadcastTransactions(trytes, [callback])](#module_core.broadcastTransactions)
 
-    * [.createCheckConsistency(provider)](#module_core.createCheckConsistency)
+    -   [.createCheckConsistency(provider)](#module_core.createCheckConsistency)
 
-    * [.checkConsistency(transactions, [options], [callback])](#module_core.checkConsistency)
+    -   [.checkConsistency(transactions, [options], [callback])](#module_core.checkConsistency)
 
-    * [.createFindTransactionObjects(provider)](#module_core.createFindTransactionObjects)
+    -   [.createFindTransactionObjects(provider)](#module_core.createFindTransactionObjects)
 
-    * [.findTransactionObjects(query, [callback])](#module_core.findTransactionObjects)
+    -   [.findTransactionObjects(query, [callback])](#module_core.findTransactionObjects)
 
-    * [.createFindTransactions(provider)](#module_core.createFindTransactions)
+    -   [.createFindTransactions(provider)](#module_core.createFindTransactions)
 
-    * [.findTransactions(query, [callback])](#module_core.findTransactions)
+    -   [.findTransactions(query, [callback])](#module_core.findTransactions)
 
-    * [.createGetAccountData(provider)](#module_core.createGetAccountData)
+    -   [.createGetAccountData(provider)](#module_core.createGetAccountData)
 
-    * [.getAccountData(seed, options, [callback])](#module_core.getAccountData)
+    -   [.getAccountData(seed, options, [callback])](#module_core.getAccountData)
 
-    * [.createGetBalances(provider)](#module_core.createGetBalances)
+    -   [.createGetBalances(provider)](#module_core.createGetBalances)
 
-    * [.getBalances(addresses, threshold, [callback])](#module_core.getBalances)
+    -   [.getBalances(addresses, threshold, [callback])](#module_core.getBalances)
 
-    * [.createGetBundle(provider)](#module_core.createGetBundle)
+    -   [.createGetBundle(provider)](#module_core.createGetBundle)
 
-    * [.getBundle(tailTransactionHash, [callback])](#module_core.getBundle)
+    -   [.getBundle(tailTransactionHash, [callback])](#module_core.getBundle)
 
-    * [.createGetInclusionStates(provider)](#module_core.createGetInclusionStates)
+    -   [.createGetInclusionStates(provider)](#module_core.createGetInclusionStates)
 
-    * [.getInclusionStates(transactions, tips, [callback])](#module_core.getInclusionStates)
+    -   [.getInclusionStates(transactions, tips, [callback])](#module_core.getInclusionStates)
 
-    * [.createGetInputs(provider)](#module_core.createGetInputs)
+    -   [.createGetInputs(provider)](#module_core.createGetInputs)
 
-    * [.getInputs(seed, [options], [callback])](#module_core.getInputs)
+    -   [.getInputs(seed, [options], [callback])](#module_core.getInputs)
 
-    * [.createGetLatestInclusion(provider)](#module_core.createGetLatestInclusion)
+    -   [.createGetLatestInclusion(provider)](#module_core.createGetLatestInclusion)
 
-    * [.getLatestInclusion(transactions, tips, [callback])](#module_core.getLatestInclusion)
+    -   [.getLatestInclusion(transactions, tips, [callback])](#module_core.getLatestInclusion)
 
-    * [.createGetNeighbors(provider)](#module_core.createGetNeighbors)
+    -   [.createGetNeighbors(provider)](#module_core.createGetNeighbors)
 
-    * [.getNeighbors([callback])](#module_core.getNeighbors)
+    -   [.getNeighbors([callback])](#module_core.getNeighbors)
 
-    * [.createGetNewAddress(provider)](#module_core.createGetNewAddress)
+    -   [.createGetNewAddress(provider)](#module_core.createGetNewAddress)
 
-    * [.getNewAddress(seed, [options], [callback])](#module_core.getNewAddress)
+    -   [.getNewAddress(seed, [options], [callback])](#module_core.getNewAddress)
 
-    * [.createGetNodeInfo(provider)](#module_core.createGetNodeInfo)
+    -   [.createGetNodeInfo(provider)](#module_core.createGetNodeInfo)
 
-    * [.getNodeInfo([callback])](#module_core.getNodeInfo)
+    -   [.getNodeInfo([callback])](#module_core.getNodeInfo)
 
-    * [.createGetTips(provider)](#module_core.createGetTips)
+    -   [.createGetTips(provider)](#module_core.createGetTips)
 
-    * [.getTips([callback])](#module_core.getTips)
+    -   [.getTips([callback])](#module_core.getTips)
 
-    * [.createGetTransactionObjects(provider)](#module_core.createGetTransactionObjects)
+    -   [.createGetTransactionObjects(provider)](#module_core.createGetTransactionObjects)
 
-    * [.getTransactionObjects(hashes, [callback])](#module_core.getTransactionObjects)
+    -   [.getTransactionObjects(hashes, [callback])](#module_core.getTransactionObjects)
 
-    * [.createGetTransactionsToApprove(provider)](#module_core.createGetTransactionsToApprove)
+    -   [.createGetTransactionsToApprove(provider)](#module_core.createGetTransactionsToApprove)
 
-    * [.getTransactionsToApprove(depth, [reference], [callback])](#module_core.getTransactionsToApprove)
+    -   [.getTransactionsToApprove(depth, [reference], [callback])](#module_core.getTransactionsToApprove)
 
-    * [.createGetTrytes(provider)](#module_core.createGetTrytes)
+    -   [.createGetTrytes(provider)](#module_core.createGetTrytes)
 
-    * [.getTrytes(hashes, [callback])](#module_core.getTrytes)
+    -   [.getTrytes(hashes, [callback])](#module_core.getTrytes)
 
-    * [.createIsPromotable(provider, [depth])](#module_core.createIsPromotable)
+    -   [.createIsPromotable(provider, [depth])](#module_core.createIsPromotable)
 
-    * [.isPromotable(tail, [callback])](#module_core.isPromotable)
+    -   [.isPromotable(tail, [callback])](#module_core.isPromotable)
 
-    * [.createPrepareTransfers([provider])](#module_core.createPrepareTransfers)
+    -   [.createPrepareTransfers([provider])](#module_core.createPrepareTransfers)
 
-    * [.prepareTransfers(seed, transfers, [options], [callback])](#module_core.prepareTransfers)
+    -   [.prepareTransfers(seed, transfers, [options], [callback])](#module_core.prepareTransfers)
 
-    * [.createPromoteTransaction(provider, [attachFn])](#module_core.createPromoteTransaction)
+    -   [.createPromoteTransaction(provider, [attachFn])](#module_core.createPromoteTransaction)
 
-    * [.promoteTransaction(tail, depth, minWeightMagnitude, transfer, [options], [callback])](#module_core.promoteTransaction)
+    -   [.promoteTransaction(tail, depth, minWeightMagnitude, transfer, [options], [callback])](#module_core.promoteTransaction)
 
-    * [.createRemoveNeighbors(provider)](#module_core.createRemoveNeighbors)
+    -   [.createRemoveNeighbors(provider)](#module_core.createRemoveNeighbors)
 
-    * [.removeNeighbors(uris, [callback])](#module_core.removeNeighbors)
+    -   [.removeNeighbors(uris, [callback])](#module_core.removeNeighbors)
 
-    * [.createReplayBundle(provider)](#module_core.createReplayBundle)
+    -   [.createReplayBundle(provider)](#module_core.createReplayBundle)
 
-    * [.replayBundle(tail, depth, minWeightMagnitude, [callback])](#module_core.replayBundle)
+    -   [.replayBundle(tail, depth, minWeightMagnitude, [callback])](#module_core.replayBundle)
 
-    * [.createSendTrytes(provider)](#module_core.createSendTrytes)
+    -   [.createSendTrytes(provider)](#module_core.createSendTrytes)
 
-    * [.sendTrytes(trytes, depth, minWeightMagnitude, [reference], [callback])](#module_core.sendTrytes)
+    -   [.sendTrytes(trytes, depth, minWeightMagnitude, [reference], [callback])](#module_core.sendTrytes)
 
-    * [.createStoreAndBroadcast(provider)](#module_core.createStoreAndBroadcast)
+    -   [.createStoreAndBroadcast(provider)](#module_core.createStoreAndBroadcast)
 
-    * [.storeAndBroadcast(trytes, [callback])](#module_core.storeAndBroadcast)
+    -   [.storeAndBroadcast(trytes, [callback])](#module_core.storeAndBroadcast)
 
-    * [.createStoreTransactions(provider)](#module_core.createStoreTransactions)
+    -   [.createStoreTransactions(provider)](#module_core.createStoreTransactions)
 
-    * [.storeTransactions(trytes, [callback])](#module_core.storeTransactions)
+    -   [.storeTransactions(trytes, [callback])](#module_core.storeTransactions)
 
-    * [.createTraverseBundle(provider)](#module_core.createTraverseBundle)
+    -   [.createTraverseBundle(provider)](#module_core.createTraverseBundle)
 
-    * [.traverseBundle(trunkTransaction, [bundle], [callback])](#module_core.traverseBundle)
+    -   [.traverseBundle(trunkTransaction, [bundle], [callback])](#module_core.traverseBundle)
 
-    * [.generateAddress(seed, index, [security], [checksum])](#module_core.generateAddress)
-
+    -   [.generateAddress(seed, index, [security], [checksum])](#module_core.generateAddress)
 
 <a name="module_core.composeApi"></a>
 
-### *core*.composeApi([settings])
+### _core_.composeApi([settings])
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| [settings] | <code>object</code> \| <code>function</code> | <code>{} | provider</code> | Connection settings or `provider` factory |
-| [settings.provider] | <code>string</code> | <code>&quot;http://localhost:14265&quot;</code> | Uri of IRI node |
-| [settings.attachToTangle] | <code>function</code> |  | Function to override [`attachToTangle`](#module_core.attachToTangle) with |
-| [settings.apiVersion] | <code>string</code> \| <code>number</code> | <code>1</code> | IOTA Api version to be sent as `X-IOTA-API-Version` header. |
-| [settings.requestBatchSize] | <code>number</code> | <code>1000</code> | Number of search values per request. |
+| Param                       | Type                                       | Default                                         | Description                                                               |
+| --------------------------- | ------------------------------------------ | ----------------------------------------------- | ------------------------------------------------------------------------- |
+| [settings]                  | <code>object</code>                        | <code>{}</code>                                 | Connection settings                                                       |
+| [settings.network]          | <code>Provider</code>                      |                                                 | Network provider, defaults to `http-client`.                              |
+| [settings.provider]         | <code>string</code>                        | <code>&quot;http://localhost:14265&quot;</code> | Uri of IRI node                                                           |
+| [settings.attachToTangle]   | <code>function</code>                      |                                                 | Function to override [`attachToTangle`](#module_core.attachToTangle) with |
+| [settings.apiVersion]       | <code>string</code> \| <code>number</code> | <code>1</code>                                  | IOTA Api version to be sent as `X-IOTA-API-Version` header.               |
+| [settings.requestBatchSize] | <code>number</code>                        | <code>1000</code>                               | Number of search values per request.                                      |
 
 Composes API object from it's components
 
 <a name="module_core.createAddNeighbors"></a>
 
-### *core*.createAddNeighbors(provider)
+### _core_.createAddNeighbors(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`addNeighbors`](#module_core.addNeighbors)  
 <a name="module_core.addNeighbors"></a>
 
-### *core*.addNeighbors(uris, [callback])
+### _core_.addNeighbors(uris, [callback])
+
 **Fulfil**: <code>number</code> Number of neighbors that were added  
 **Reject**: <code>Error</code>
-- `INVALID_URI`: Invalid uri
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| uris | <code>Array</code> | List of URI's |
+-   `INVALID_URI`: Invalid uri
+-   Fetch error
+
+| Param      | Type                  | Description       |
+| ---------- | --------------------- | ----------------- |
+| uris       | <code>Array</code>    | List of URI's     |
 | [callback] | <code>Callback</code> | Optional callback |
 
 Adds a list of neighbors to the connected IRI node by calling
@@ -190,52 +192,58 @@ Assumes `addNeighbors` command is available on the node.
 
 `addNeighbors` has temporary effect until your node relaunches.
 
-**Example**  
+**Example**
+
 ```js
 addNeighbors(['udp://148.148.148.148:14265'])
-  .then(numAdded => {
-    // ...
-  }).catch(err => {
-    // ...
-  })
+    .then(numAdded => {
+        // ...
+    })
+    .catch(err => {
+        // ...
+    })
 ```
+
 <a name="module_core.createAttachToTangle"></a>
 
-### *core*.createAttachToTangle(provider)
+### _core_.createAttachToTangle(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`attachToTangle`](#module_core.attachToTangle)  
 <a name="module_core.attachToTangle"></a>
 
-### *core*.attachToTangle(trunkTransaction, branchTransaction, minWeightMagnitude, trytes, [callback])
+### _core_.attachToTangle(trunkTransaction, branchTransaction, minWeightMagnitude, trytes, [callback])
+
 **Fulfil**: <code>TransactionTrytes[]</code> Array of transaction trytes with nonce and attachment timestamps  
 **Reject**: <code>Error</code>
-- `INVALID_TRUNK_TRANSACTION`: Invalid `trunkTransaction`
-- `INVALID_BRANCH_TRANSACTION`: Invalid `branchTransaction`
-- `INVALID_MIN_WEIGHT_MAGNITUDE`: Invalid `minWeightMagnitude` argument
-- `INVALID_TRANSACTION_TRYTES`: Invalid transaction trytes
-- `INVALID_TRANSACTIONS_TO_APPROVE`: Invalid transactions to approve
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| trunkTransaction | <code>Hash</code> | Trunk transaction as returned by [`getTransactionsToApprove`](#module_core.getTransactionsToApprove) |
-| branchTransaction | <code>Hash</code> | Branch transaction as returned by [`getTransactionsToApprove`](#module_core.getTransactionsToApprove) |
-| minWeightMagnitude | <code>number</code> | Number of minimun trailing zeros in tail transaction hash |
-| trytes | <code>Array.&lt;TransactionTrytes&gt;</code> | List of transaction trytes |
-| [callback] | <code>Callback</code> | Optional callback |
+-   `INVALID_TRUNK_TRANSACTION`: Invalid `trunkTransaction`
+-   `INVALID_BRANCH_TRANSACTION`: Invalid `branchTransaction`
+-   `INVALID_MIN_WEIGHT_MAGNITUDE`: Invalid `minWeightMagnitude` argument
+-   `INVALID_TRANSACTION_TRYTES`: Invalid transaction trytes
+-   `INVALID_TRANSACTIONS_TO_APPROVE`: Invalid transactions to approve
+-   Fetch error
+
+| Param              | Type                                         | Description                                                                                           |
+| ------------------ | -------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| trunkTransaction   | <code>Hash</code>                            | Trunk transaction as returned by [`getTransactionsToApprove`](#module_core.getTransactionsToApprove)  |
+| branchTransaction  | <code>Hash</code>                            | Branch transaction as returned by [`getTransactionsToApprove`](#module_core.getTransactionsToApprove) |
+| minWeightMagnitude | <code>number</code>                          | Number of minimun trailing zeros in tail transaction hash                                             |
+| trytes             | <code>Array.&lt;TransactionTrytes&gt;</code> | List of transaction trytes                                                                            |
+| [callback]         | <code>Callback</code>                        | Optional callback                                                                                     |
 
 Performs the Proof-of-Work required to attach a transaction to the Tangle by
 calling [`attachToTangle`](https://docs.iota.works/iri/api#endpoints/attachToTangle) command.
 Returns list of transaction trytes and overwrites the following fields:
- - `hash`
- - `nonce`
- - `attachmentTimestamp`
- - `attachmentTimsetampLowerBound`
- - `attachmentTimestampUpperBound`
+
+-   `hash`
+-   `nonce`
+-   `attachmentTimestamp`
+-   `attachmentTimsetampLowerBound`
+-   `attachmentTimestampUpperBound`
 
 This method can be replaced with a local equivelant such as
 [`ccurl.interface.js`](https://github.com/iotaledger/ccurl.interface.js) in node.js,
@@ -245,80 +253,88 @@ or remote [`PoWbox`](https://powbox.devnet.iota.org/).
 `trunkTransaction` and `branchTransaction` hashes are given by
 [`getTransactionToApprove`](#module_core.getTransactionsToApprove).
 
-**Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
+**Note:** Persist the transaction trytes in local storage **before** calling this command, to ensure
 that reattachment is possible, until your bundle has been included.
 
-**Example**  
+**Example**
+
 ```js
 getTransactionsToApprove(depth)
-  .then(({ trunkTransaction, branchTransaction }) =>
-    attachToTangle(trunkTransaction, branchTransaction, minWightMagnitude, trytes)
-  )
-  .then(attachedTrytes => {
-    // ...
-  })
-  .catch(err => {
-    // ...
-  })
+    .then(({ trunkTransaction, branchTransaction }) =>
+        attachToTangle(trunkTransaction, branchTransaction, minWightMagnitude, trytes)
+    )
+    .then(attachedTrytes => {
+        // ...
+    })
+    .catch(err => {
+        // ...
+    })
 ```
+
 <a name="module_core.createBroadcastBundle"></a>
 
-### *core*.createBroadcastBundle(provider)
+### _core_.createBroadcastBundle(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`broadcastBundle`](#module_core.broadcastBundle)  
 <a name="module_core.broadcastBundle"></a>
 
-### *core*.broadcastBundle(tailTransactionHash, [callback])
+### _core_.broadcastBundle(tailTransactionHash, [callback])
+
 **Fulfil**: <code>Transaction[]</code> List of transaction objects  
 **Reject**: <code>Error</code>
-- `INVALID_HASH`: Invalid tail transaction hash
-- `INVALID_BUNDLE`: Invalid bundle
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| tailTransactionHash | <code>Hash</code> | Tail transaction hash |
-| [callback] | <code>Callback</code> | Optional callback |
+-   `INVALID_HASH`: Invalid tail transaction hash
+-   `INVALID_BUNDLE`: Invalid bundle
+-   Fetch error
+
+| Param               | Type                  | Description           |
+| ------------------- | --------------------- | --------------------- |
+| tailTransactionHash | <code>Hash</code>     | Tail transaction hash |
+| [callback]          | <code>Callback</code> | Optional callback     |
 
 Re-broadcasts all transactions in a bundle given the tail transaction hash.
 It might be useful when transactions did not properly propagate,
 particularly in the case of large bundles.
 
-**Example**  
+**Example**
+
 ```js
 broadcastBundle(tailHash)
-  .then(transactions => {
-     // ...
-  })
-  .catch(err => {
-    // ...
-  })
+    .then(transactions => {
+        // ...
+    })
+    .catch(err => {
+        // ...
+    })
 ```
+
 <a name="module_core.createBroadcastTransactions"></a>
 
-### *core*.createBroadcastTransactions(provider)
+### _core_.createBroadcastTransactions(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`broadcastTransactions`](#module_core.broadcastTransactions)  
 <a name="module_core.broadcastTransactions"></a>
 
-### *core*.broadcastTransactions(trytes, [callback])
+### _core_.broadcastTransactions(trytes, [callback])
+
 **Fulfil**: <code>Trytes[]</code> Attached transaction trytes  
 **Reject**: <code>Error</code>
-- `INVALID_ATTACHED_TRYTES`: Invalid array of attached trytes
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| trytes | <code>Array.&lt;TransactionTrytes&gt;</code> | Attached Transaction trytes |
-| [callback] | <code>Callback</code> | Optional callback |
+-   `INVALID_ATTACHED_TRYTES`: Invalid array of attached trytes
+-   Fetch error
+
+| Param      | Type                                         | Description                 |
+| ---------- | -------------------------------------------- | --------------------------- |
+| trytes     | <code>Array.&lt;TransactionTrytes&gt;</code> | Attached Transaction trytes |
+| [callback] | <code>Callback</code>                        | Optional callback           |
 
 Broadcasts an list of _attached_ transaction trytes to the network by calling
 [`boradcastTransactions`](https://docs.iota.org/iri/api#endpoints/broadcastTransactions) command.
@@ -329,43 +345,47 @@ Tip selection and Proof-of-Work must be done first, by calling
 
 You may use this method to increase odds of effective transaction propagation.
 
-**Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
+**Note:** Persist the transaction trytes in local storage **before** calling this command, to ensure
 that reattachment is possible, until your bundle has been included.
 
-**Example**  
+**Example**
+
 ```js
 broadcastTransactions(trytes)
-  .then(trytes => {
-     // ...
-  })
-  .catch(err => {
-    // ...
-  })
+    .then(trytes => {
+        // ...
+    })
+    .catch(err => {
+        // ...
+    })
 ```
+
 <a name="module_core.createCheckConsistency"></a>
 
-### *core*.createCheckConsistency(provider)
+### _core_.createCheckConsistency(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`checkConsistency`](#module_core.checkConsistency)  
 <a name="module_core.checkConsistency"></a>
 
-### *core*.checkConsistency(transactions, [options], [callback])
+### _core_.checkConsistency(transactions, [options], [callback])
+
 **Fulfil**: <code>boolean</code> Consistency state of given transaction or co-consistency of given transactions.  
 **Reject**: <code>Error</code>
-- `INVALID_TRANSACTION_HASH`: Invalid transaction hash
-- Fetch error
-- Reason for returning `false`, if called with `options.rejectWithReason`  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| transactions | <code>Hash</code> \| <code>Array.&lt;Hash&gt;</code> | Tail transaction hash (hash of transaction with `currentIndex=0`), or array of tail transaction hashes. |
-| [options] | <code>object</code> | Options |
-| [options.rejectWithReason] | <code>boolean</code> | Enables rejection if state is `false`, with reason as error message |
-| [callback] | <code>Callback</code> | Optional callback. |
+-   `INVALID_TRANSACTION_HASH`: Invalid transaction hash
+-   Fetch error
+-   Reason for returning `false`, if called with `options.rejectWithReason`
+
+| Param                      | Type                                                 | Description                                                                                             |
+| -------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| transactions               | <code>Hash</code> \| <code>Array.&lt;Hash&gt;</code> | Tail transaction hash (hash of transaction with `currentIndex=0`), or array of tail transaction hashes. |
+| [options]                  | <code>object</code>                                  | Options                                                                                                 |
+| [options.rejectWithReason] | <code>boolean</code>                                 | Enables rejection if state is `false`, with reason as error message                                     |
+| [callback]                 | <code>Callback</code>                                | Optional callback.                                                                                      |
 
 Checks if a transaction is _consistent_ or a set of transactions are _co-consistent_, by calling
 [`checkConsistency`](https://docs.iota.org/iri/api#endpoints/checkConsistency) command.
@@ -376,17 +396,20 @@ As long as a transaction is consistent it might be accepted by the network.
 In case transaction is inconsistent, it will not be accepted, and a reattachment
 is required by calling [`replaybundle`](#module_core.replayBundle).
 
-**Example**  
+**Example**
+
 ```js
 checkConsistency(tailHash)
-  .then(isConsistent => {
-    // ...
-  })
-  .catch(err => {
-    // ...
-  })
+    .then(isConsistent => {
+        // ...
+    })
+    .catch(err => {
+        // ...
+    })
 ```
-**Example**  
+
+**Example**
+
 ##### Example with `checkConsistency` & `isPromotable`
 
 Consistent transactions might remain pending due to networking issues,
@@ -398,51 +421,48 @@ or [_reattached_](replayBundle).
 This functionality is abstracted in [`isPromotable`](isPromotable).
 
 ```js
-const isAboveMaxDepth = attachmentTimestamp => (
-   // Check against future timestamps
-   attachmentTimestamp < Date.now() &&
-   // Check if transaction wasn't issued before last 6 milestones
-   // Milestones are being issued every ~2mins
-   Date.now() - attachmentTimestamp < 11 * 60 * 1000
-)
+const isAboveMaxDepth = attachmentTimestamp =>
+    // Check against future timestamps
+    attachmentTimestamp < Date.now() &&
+    // Check if transaction wasn't issued before last 6 milestones
+    // Milestones are being issued every ~2mins
+    Date.now() - attachmentTimestamp < 11 * 60 * 1000
 
-const isPromotable = ({ hash, attachmentTimestamp }) => (
-  checkConsistency(hash)
-     .then(isConsistent => (
-       isConsistent &&
-       isAboveMaxDepth(attachmentTimestamp)
-     ))
-)
+const isPromotable = ({ hash, attachmentTimestamp }) =>
+    checkConsistency(hash).then(isConsistent => isConsistent && isAboveMaxDepth(attachmentTimestamp))
 ```
+
 <a name="module_core.createFindTransactionObjects"></a>
 
-### *core*.createFindTransactionObjects(provider)
+### _core_.createFindTransactionObjects(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description                        |
+| -------- | --------------------- | ---------------------------------- |
 | provider | <code>Provider</code> | Network provider for accessing IRI |
 
 **Returns**: <code>function</code> - [`findTransactionObjects`](#module_core.findTransactionObjects)  
 <a name="module_core.findTransactionObjects"></a>
 
-### *core*.findTransactionObjects(query, [callback])
+### _core_.findTransactionObjects(query, [callback])
+
 **Fulfil**: <code>Transaction[]</code> Array of transaction objects  
 **Reject**: <code>Error</code>
-- `INVALID_SEARCH_KEY`
-- `INVALID_HASH`: Invalid bundle hash
-- `INVALID_TRANSACTION_HASH`: Invalid approvee transaction hash
-- `INVALID_ADDRESS`: Invalid address
-- `INVALID_TAG`: Invalid tag
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| query | <code>object</code> |  |
-| [query.addresses] | <code>Array.&lt;Hash&gt;</code> | List of addresses |
-| [query.bundles] | <code>Array.&lt;Hash&gt;</code> | List of bundle hashes |
-| [query.tags] | <code>Array.&lt;Tag&gt;</code> | List of tags |
-| [query.addresses] | <code>Array.&lt;Hash&gt;</code> | List of approvees |
-| [callback] | <code>Callback</code> | Optional callback |
+-   `INVALID_SEARCH_KEY`
+-   `INVALID_HASH`: Invalid bundle hash
+-   `INVALID_TRANSACTION_HASH`: Invalid approvee transaction hash
+-   `INVALID_ADDRESS`: Invalid address
+-   `INVALID_TAG`: Invalid tag
+-   Fetch error
+
+| Param             | Type                            | Description           |
+| ----------------- | ------------------------------- | --------------------- |
+| query             | <code>object</code>             |                       |
+| [query.addresses] | <code>Array.&lt;Hash&gt;</code> | List of addresses     |
+| [query.bundles]   | <code>Array.&lt;Hash&gt;</code> | List of bundle hashes |
+| [query.tags]      | <code>Array.&lt;Tag&gt;</code>  | List of tags          |
+| [query.addresses] | <code>Array.&lt;Hash&gt;</code> | List of approvees     |
+| [callback]        | <code>Callback</code>           | Optional callback     |
 
 Wrapper function for [`findTransactions`](#module_core.findTransactions) and
 [`getTrytes`](#module_core.getTrytes).
@@ -454,482 +474,531 @@ Searching for transactions by address:
 
 ```js
 findTransactionObjects({ addresses: ['ADR...'] })
-   .then(transactions => {
-       // ...
-   })
-   .catch(err => {
-       // ...
-   })
+    .then(transactions => {
+        // ...
+    })
+    .catch(err => {
+        // ...
+    })
 ```
+
 <a name="module_core.createFindTransactions"></a>
 
-### *core*.createFindTransactions(provider)
+### _core_.createFindTransactions(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description                        |
+| -------- | --------------------- | ---------------------------------- |
 | provider | <code>Provider</code> | Network provider for accessing IRI |
 
 **Returns**: <code>function</code> - [`findTransactionObjects`](#module_core.findTransactions)  
 <a name="module_core.findTransactions"></a>
 
-### *core*.findTransactions(query, [callback])
+### _core_.findTransactions(query, [callback])
+
 **Fulfil**: <code>Hash[]</code> Array of transaction hashes  
 **Reject**: <code>Error</code>
-- `INVALID_SEARCH_KEY`
-- `INVALID_HASH`: Invalid bundle hash
-- `INVALID_TRANSACTION_HASH`: Invalid approvee transaction hash
-- `INVALID_ADDRESS`: Invalid address
-- `INVALID_TAG`: Invalid tag
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| query | <code>object</code> |  |
-| [query.addresses] | <code>Array.&lt;Hash&gt;</code> | List of addresses |
-| [query.bundles] | <code>Array.&lt;Hash&gt;</code> | List of bundle hashes |
-| [query.tags] | <code>Array.&lt;Tag&gt;</code> | List of tags |
-| [query.addresses] | <code>Array.&lt;Hash&gt;</code> | List of approvees |
-| [callback] | <code>Callback</code> | Optional callback |
+-   `INVALID_SEARCH_KEY`
+-   `INVALID_HASH`: Invalid bundle hash
+-   `INVALID_TRANSACTION_HASH`: Invalid approvee transaction hash
+-   `INVALID_ADDRESS`: Invalid address
+-   `INVALID_TAG`: Invalid tag
+-   Fetch error
 
-Searches for transaction `hashes`  by calling
+| Param             | Type                            | Description           |
+| ----------------- | ------------------------------- | --------------------- |
+| query             | <code>object</code>             |                       |
+| [query.addresses] | <code>Array.&lt;Hash&gt;</code> | List of addresses     |
+| [query.bundles]   | <code>Array.&lt;Hash&gt;</code> | List of bundle hashes |
+| [query.tags]      | <code>Array.&lt;Tag&gt;</code>  | List of tags          |
+| [query.addresses] | <code>Array.&lt;Hash&gt;</code> | List of approvees     |
+| [callback]        | <code>Callback</code>           | Optional callback     |
+
+Searches for transaction `hashes` by calling
 [`findTransactions`](https://docs.iota.org/iri/api#endpoints/findTransactions) command.
 It allows to search for transactions by passing a `query` object with `addresses`, `tags` and `approvees` fields.
 Multiple query fields are supported and `findTransactions` returns intersection of results.
 
-**Example**  
+**Example**
+
 ```js
 findTransactions({ addresses: ['ADRR...'] })
-   .then(hashes => {
-       // ...
-   })
-   .catch(err => {
-       // handle errors here
-   })
+    .then(hashes => {
+        // ...
+    })
+    .catch(err => {
+        // handle errors here
+    })
 ```
+
 <a name="module_core.createGetAccountData"></a>
 
-### *core*.createGetAccountData(provider)
+### _core_.createGetAccountData(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description                        |
+| -------- | --------------------- | ---------------------------------- |
 | provider | <code>Provider</code> | Network provider for accessing IRI |
 
 **Returns**: <code>function</code> - [`getAccountData`](#module_core.getAccountData)  
 <a name="module_core.getAccountData"></a>
 
-### *core*.getAccountData(seed, options, [callback])
+### _core_.getAccountData(seed, options, [callback])
+
 **Fulfil**: <code>AccountData</code>  
 **Reject**: <code>Error</code>
-- `INVALID_SEED`
-- `INVALID_START_OPTION`
-- `INVALID_START_END_OPTIONS`: Invalid combination of start & end options`
-- Fetch error  
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| seed | <code>string</code> |  |  |
-| options | <code>object</code> |  |  |
-| [options.start] | <code>number</code> | <code>0</code> | Starting key index |
-| [options.security] | <code>number</code> | <code>0</code> | Security level to be used for getting inputs and addresses |
-| [options.end] | <code>number</code> |  | Ending key index |
-| [callback] | <code>Callback</code> |  | Optional callback |
+-   `INVALID_SEED`
+-   `INVALID_START_OPTION`
+-   `INVALID_START_END_OPTIONS`: Invalid combination of start & end options`
+-   Fetch error
+
+| Param              | Type                  | Default        | Description                                                |
+| ------------------ | --------------------- | -------------- | ---------------------------------------------------------- |
+| seed               | <code>string</code>   |                |                                                            |
+| options            | <code>object</code>   |                |                                                            |
+| [options.start]    | <code>number</code>   | <code>0</code> | Starting key index                                         |
+| [options.security] | <code>number</code>   | <code>0</code> | Security level to be used for getting inputs and addresses |
+| [options.end]      | <code>number</code>   |                | Ending key index                                           |
+| [callback]         | <code>Callback</code> |                | Optional callback                                          |
 
 Returns an `AccountData` object, containing account information about `addresses`, `transactions`,
 `inputs` and total account balance.
 
-**Example**  
+**Example**
+
 ```js
 getAccountData(seed, {
-   start: 0,
-   security: 2
+    start: 0,
+    security: 2,
 })
-  .then(accountData => {
-    const { addresses, inputs, transactions, balance } = accountData
-    // ...
-  })
-  .catch(err => {
-    // ...
-  })
+    .then(accountData => {
+        const { addresses, inputs, transactions, balance } = accountData
+        // ...
+    })
+    .catch(err => {
+        // ...
+    })
 ```
+
 <a name="module_core.createGetBalances"></a>
 
-### *core*.createGetBalances(provider)
+### _core_.createGetBalances(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`getBalances`](#module_core.getBalances)  
 <a name="module_core.getBalances"></a>
 
-### *core*.getBalances(addresses, threshold, [callback])
+### _core_.getBalances(addresses, threshold, [callback])
+
 **Fulfil**: <code>Balances</code> Object with list of `balances` and corresponding `milestone`  
 **Reject**: <code>Error</code>
-- `INVALID_HASH`: Invalid address
-- `INVALID_THRESHOLD`: Invalid `threshold`
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| addresses | <code>Array.&lt;Hash&gt;</code> | List of addresses |
-| threshold | <code>number</code> | Confirmation threshold, currently `100` should be used |
-| [callback] | <code>Callback</code> | Optional callback |
+-   `INVALID_HASH`: Invalid address
+-   `INVALID_THRESHOLD`: Invalid `threshold`
+-   Fetch error
+
+| Param      | Type                            | Description                                            |
+| ---------- | ------------------------------- | ------------------------------------------------------ |
+| addresses  | <code>Array.&lt;Hash&gt;</code> | List of addresses                                      |
+| threshold  | <code>number</code>             | Confirmation threshold, currently `100` should be used |
+| [callback] | <code>Callback</code>           | Optional callback                                      |
 
 Fetches _confirmed_ balances of given addresses at the latest solid milestone,
 by calling [`getBalances`](https://docs.iota.works/iri/api#endpoints/getBalances) command.
 
-**Example**  
+**Example**
+
 ```js
 getBalances([address], 100)
-  .then(({ balances }) => {
-    // ...
-  })
-  .catch(err => {
-    // ...
-  })
+    .then(({ balances }) => {
+        // ...
+    })
+    .catch(err => {
+        // ...
+    })
 ```
+
 <a name="module_core.createGetBundle"></a>
 
-### *core*.createGetBundle(provider)
+### _core_.createGetBundle(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description                        |
+| -------- | --------------------- | ---------------------------------- |
 | provider | <code>Provider</code> | Network provider for accessing IRI |
 
 **Returns**: <code>function</code> - [`getBundle`](#module_core.getBundle)  
 <a name="module_core.getBundle"></a>
 
-### *core*.getBundle(tailTransactionHash, [callback])
+### _core_.getBundle(tailTransactionHash, [callback])
+
 **Fulfil**: <code>Transaction[]</code> Bundle as array of transaction objects  
 **Reject**: <code>Error</code>
-- `INVALID_TRANSACTION_HASH`
-- `INVALID_TAIL_HASH`: Provided transaction is not tail (`currentIndex !== 0`)
-- `INVALID_BUNDLE`: Bundle is syntactically invalid
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| tailTransactionHash | <code>Hash</code> | Tail transaction hash |
-| [callback] | <code>Callback</code> | Optional callback |
+-   `INVALID_TRANSACTION_HASH`
+-   `INVALID_TAIL_HASH`: Provided transaction is not tail (`currentIndex !== 0`)
+-   `INVALID_BUNDLE`: Bundle is syntactically invalid
+-   Fetch error
+
+| Param               | Type                  | Description           |
+| ------------------- | --------------------- | --------------------- |
+| tailTransactionHash | <code>Hash</code>     | Tail transaction hash |
+| [callback]          | <code>Callback</code> | Optional callback     |
 
 Fetches and validates the bundle given a _tail_ transaction hash, by calling
 [`traverseBundle`](#module_core.traverseBundle) and traversing through `trunkTransaction`.
 
-**Example**  
+**Example**
+
 ```js
 getBundle(tail)
-   .then(bundle => {
-       // ...
-   })
-   .catch(err => {
-       // handle errors
-   })
+    .then(bundle => {
+        // ...
+    })
+    .catch(err => {
+        // handle errors
+    })
 ```
+
 <a name="module_core.createGetInclusionStates"></a>
 
-### *core*.createGetInclusionStates(provider)
+### _core_.createGetInclusionStates(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description                        |
+| -------- | --------------------- | ---------------------------------- |
 | provider | <code>Provider</code> | Network provider for accessing IRI |
 
 **Returns**: <code>function</code> - [`getInclusionStates`](#module_core.getInclusionStates)  
 <a name="module_core.getInclusionStates"></a>
 
-### *core*.getInclusionStates(transactions, tips, [callback])
+### _core_.getInclusionStates(transactions, tips, [callback])
+
 **Fulfil**: <code>boolean[]</code> Array of inclusion state  
 **Reject**: <code>Error</code>
-- `INVALID_TRANSACTION_HASH`: Invalid `hashes` or `tips`
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| transactions | <code>Array.&lt;Hash&gt;</code> | List of transaction hashes |
-| tips | <code>Array.&lt;Hash&gt;</code> | List of tips to check if transactions are referenced by |
-| [callback] | <code>Callback</code> | Optional callback |
+-   `INVALID_TRANSACTION_HASH`: Invalid `hashes` or `tips`
+-   Fetch error
+
+| Param        | Type                            | Description                                             |
+| ------------ | ------------------------------- | ------------------------------------------------------- |
+| transactions | <code>Array.&lt;Hash&gt;</code> | List of transaction hashes                              |
+| tips         | <code>Array.&lt;Hash&gt;</code> | List of tips to check if transactions are referenced by |
+| [callback]   | <code>Callback</code>           | Optional callback                                       |
 
 Fetches inclusion states of given list of transactions, by calling
 [`getInclusionStates`](https://docs.iota.works/iri/api#endpoints/getInclusionsStates) command.
 
-**Example**  
+**Example**
+
 ```js
 getInclusionStates(transactions)
-  .then(states => {
-    // ...
-  })
-  .catch(err => {
-    // ...
-  })
+    .then(states => {
+        // ...
+    })
+    .catch(err => {
+        // ...
+    })
 ```
+
 <a name="module_core.createGetInputs"></a>
 
-### *core*.createGetInputs(provider)
+### _core_.createGetInputs(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description                        |
+| -------- | --------------------- | ---------------------------------- |
 | provider | <code>Provider</code> | Network provider for accessing IRI |
 
 **Returns**: <code>function</code> - [`getInputs`](#module_core.getInputs)  
 <a name="module_core.getInputs"></a>
 
-### *core*.getInputs(seed, [options], [callback])
+### _core_.getInputs(seed, [options], [callback])
+
 **Fulfil**: <code>Inputs</code> Inputs object containg a list of `[Address](Address)` objects and `totalBalance` field  
 **Reject**: <code>Error</code>
-- `INVALID_SEED`
-- `INVALID_SECURITY_LEVEL`
-- `INVALID_START_OPTION`
-- `INVALID_START_END_OPTIONS`
-- `INVALID_THRESHOLD`
-- `INSUFFICIENT_BALANCE`
-- Fetch error  
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| seed | <code>string</code> |  |  |
-| [options] | <code>object</code> |  |  |
-| [options.start] | <code>number</code> | <code>0</code> | Index offset indicating from which address we start scanning for balance |
-| [options.end] | <code>number</code> |  | Last index up to which we stop scanning |
-| [options.security] | <code>number</code> | <code>2</code> | Security level of inputs |
-| [options.threshold] | <code>threshold</code> |  | Minimum amount of balance required |
-| [callback] | <code>Callback</code> |  | Optional callback |
+-   `INVALID_SEED`
+-   `INVALID_SECURITY_LEVEL`
+-   `INVALID_START_OPTION`
+-   `INVALID_START_END_OPTIONS`
+-   `INVALID_THRESHOLD`
+-   `INSUFFICIENT_BALANCE`
+-   Fetch error
+
+| Param               | Type                   | Default        | Description                                                              |
+| ------------------- | ---------------------- | -------------- | ------------------------------------------------------------------------ |
+| seed                | <code>string</code>    |                |                                                                          |
+| [options]           | <code>object</code>    |                |                                                                          |
+| [options.start]     | <code>number</code>    | <code>0</code> | Index offset indicating from which address we start scanning for balance |
+| [options.end]       | <code>number</code>    |                | Last index up to which we stop scanning                                  |
+| [options.security]  | <code>number</code>    | <code>2</code> | Security level of inputs                                                 |
+| [options.threshold] | <code>threshold</code> |                | Minimum amount of balance required                                       |
+| [callback]          | <code>Callback</code>  |                | Optional callback                                                        |
 
 Creates and returns an `Inputs` object by generating addresses and fetching their latest balance.
 
-**Example**  
+**Example**
+
 ```js
 getInputs(seed, { start: 0, threhold })
-  .then(({ inputs, totalBalance }) => {
-    // ...
-  })
-  .catch(err => {
-    if (err.message === errors.INSUFFICIENT_BALANCE) {
-       // ...
-    }
-    // ...
-  })
+    .then(({ inputs, totalBalance }) => {
+        // ...
+    })
+    .catch(err => {
+        if (err.message === errors.INSUFFICIENT_BALANCE) {
+            // ...
+        }
+        // ...
+    })
 ```
+
 <a name="module_core.createGetLatestInclusion"></a>
 
-### *core*.createGetLatestInclusion(provider)
+### _core_.createGetLatestInclusion(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description                        |
+| -------- | --------------------- | ---------------------------------- |
 | provider | <code>Provider</code> | Network provider for accessing IRI |
 
 **Returns**: <code>function</code> - [`getLatestInclusion`](#module_core.getLatestInclusion)  
 <a name="module_core.getLatestInclusion"></a>
 
-### *core*.getLatestInclusion(transactions, tips, [callback])
+### _core_.getLatestInclusion(transactions, tips, [callback])
+
 **Fulfil**: <code>boolean[]</code> List of inclusion states  
 **Reject**: <code>Error</code>
-- `INVALID_HASH`: Invalid transaction hash
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| transactions | <code>Array.&lt;Hash&gt;</code> | List of transactions hashes |
-| tips | <code>number</code> | List of tips to check if transactions are referenced by |
-| [callback] | <code>Callback</code> | Optional callback |
+-   `INVALID_HASH`: Invalid transaction hash
+-   Fetch error
+
+| Param        | Type                            | Description                                             |
+| ------------ | ------------------------------- | ------------------------------------------------------- |
+| transactions | <code>Array.&lt;Hash&gt;</code> | List of transactions hashes                             |
+| tips         | <code>number</code>             | List of tips to check if transactions are referenced by |
+| [callback]   | <code>Callback</code>           | Optional callback                                       |
 
 Fetches inclusion states of given transactions and a list of tips,
 by calling [`getInclusionStates`](#module_core.getInclusionStates) on `latestSolidSubtangleMilestone`.
 
-**Example**  
+**Example**
+
 ```js
 getLatestInclusion(hashes)
-   .then(states => {
-       // ...
-   })
-   .catch(err => {
-       // handle error
-   })
+    .then(states => {
+        // ...
+    })
+    .catch(err => {
+        // handle error
+    })
 ```
+
 <a name="module_core.createGetNeighbors"></a>
 
-### *core*.createGetNeighbors(provider)
+### _core_.createGetNeighbors(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`getNeighbors`](#module_core.getNeighbors)  
 <a name="module_core.getNeighbors"></a>
 
-### *core*.getNeighbors([callback])
+### _core_.getNeighbors([callback])
+
 **Fulfil**: <code>Neighbors</code>  
 **Reject**: <code>Error</code>
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
+-   Fetch error
+
+| Param      | Type                  | Description       |
+| ---------- | --------------------- | ----------------- |
 | [callback] | <code>Callback</code> | Optional callback |
 
 Returns list of connected neighbors.
 
 <a name="module_core.createGetNewAddress"></a>
 
-### *core*.createGetNewAddress(provider)
+### _core_.createGetNewAddress(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`getNewAddress`](#module_core.getNewAddress)  
 <a name="module_core.getNewAddress"></a>
 
-### *core*.getNewAddress(seed, [options], [callback])
+### _core_.getNewAddress(seed, [options], [callback])
+
 **Fulfil**: <code>Hash\|Hash[]</code> New (unused) address or list of addresses up to (and including) first unused address  
 **Reject**: <code>Error</code>
-- `INVALID_SEED`
-- `INVALID_START_OPTION`
-- `INVALID_SECURITY`
-- Fetch error  
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| seed | <code>string</code> |  | At least 81 trytes long seed |
-| [options] | <code>object</code> |  |  |
-| [options.index] | <code>number</code> | <code>0</code> | Key index to start search at |
-| [options.security] | <code>number</code> | <code>2</code> | Security level |
-| [options.checksum] | <code>boolean</code> | <code>false</code> | `Deprecated` Flag to include 9-trytes checksum or not |
-| [options.total] | <code>number</code> |  | `Deprecated` Number of addresses to generate. |
-| [options.returnAll] | <code>boolean</code> | <code>false</code> | `Deprecated` Flag to return all addresses, from start up to new address. |
-| [callback] | <code>Callback</code> |  | Optional callback |
+-   `INVALID_SEED`
+-   `INVALID_START_OPTION`
+-   `INVALID_SECURITY`
+-   Fetch error
+
+| Param               | Type                  | Default            | Description                                                              |
+| ------------------- | --------------------- | ------------------ | ------------------------------------------------------------------------ |
+| seed                | <code>string</code>   |                    | At least 81 trytes long seed                                             |
+| [options]           | <code>object</code>   |                    |                                                                          |
+| [options.index]     | <code>number</code>   | <code>0</code>     | Key index to start search at                                             |
+| [options.security]  | <code>number</code>   | <code>2</code>     | Security level                                                           |
+| [options.checksum]  | <code>boolean</code>  | <code>false</code> | `Deprecated` Flag to include 9-trytes checksum or not                    |
+| [options.total]     | <code>number</code>   |                    | `Deprecated` Number of addresses to generate.                            |
+| [options.returnAll] | <code>boolean</code>  | <code>false</code> | `Deprecated` Flag to return all addresses, from start up to new address. |
+| [callback]          | <code>Callback</code> |                    | Optional callback                                                        |
 
 Generates and returns a new address by calling [`findTransactions`](#module_core.findTransactions)
 until the first unused address is detected. This stops working after a snapshot.
 
-**Example**  
+**Example**
+
 ```js
 getNewAddress(seed, { index })
-  .then(address => {
-    // ...
-  })
-  .catch(err => {
-    // ...
-  })
+    .then(address => {
+        // ...
+    })
+    .catch(err => {
+        // ...
+    })
 ```
+
 <a name="module_core.createGetNodeInfo"></a>
 
-### *core*.createGetNodeInfo(provider)
+### _core_.createGetNodeInfo(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`getNodeInfo`](#module_core.getNodeInfo)  
 <a name="module_core.getNodeInfo"></a>
 
-### *core*.getNodeInfo([callback])
+### _core_.getNodeInfo([callback])
+
 **Fulfil**: <code>NodeInfo</code> Object with information about connected node.  
 **Reject**: <code>Error</code>
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
+-   Fetch error
+
+| Param      | Type                  | Description       |
+| ---------- | --------------------- | ----------------- |
 | [callback] | <code>Callback</code> | Optional callback |
 
 Returns information about connected node by calling
 [`getNodeInfo`](https://docs.iota.works/iri/api#endpoints/getNodeInfo) command.
 
-**Example**  
+**Example**
+
 ```js
 getNodeInfo()
-  .then(info => console.log(info))
-  .catch(err => {
-    // ...
-  })
+    .then(info => console.log(info))
+    .catch(err => {
+        // ...
+    })
 ```
+
 <a name="module_core.createGetTips"></a>
 
-### *core*.createGetTips(provider)
+### _core_.createGetTips(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`getTips`](#module_core.getTips)  
 <a name="module_core.getTips"></a>
 
-### *core*.getTips([callback])
+### _core_.getTips([callback])
+
 **Fulfil**: <code>Hash[]</code> List of tip hashes  
 **Reject**: <code>Error</code>
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
+-   Fetch error
+
+| Param      | Type                  | Description       |
+| ---------- | --------------------- | ----------------- |
 | [callback] | <code>Callback</code> | Optional callback |
 
 Returns a list of tips (transactions not referenced by other transactions),
 as seen by the connected node.
 
-**Example**  
+**Example**
+
 ```js
 getTips()
-  .then(tips => {
-    // ...
-  })
-  .catch(err => {
-    // ...
-  })
+    .then(tips => {
+        // ...
+    })
+    .catch(err => {
+        // ...
+    })
 ```
+
 <a name="module_core.createGetTransactionObjects"></a>
 
-### *core*.createGetTransactionObjects(provider)
+### _core_.createGetTransactionObjects(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`getTransactionObjects`](#module_core.getTransactionObjects)  
 <a name="module_core.getTransactionObjects"></a>
 
-### *core*.getTransactionObjects(hashes, [callback])
+### _core_.getTransactionObjects(hashes, [callback])
+
 **Fulfil**: <code>Transaction[]</code> - List of transaction objects  
 **Reject**: <code>Error</code>
-- `INVALID_TRANSACTION_HASH`
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| hashes | <code>Array.&lt;Hash&gt;</code> | Array of transaction hashes |
-| [callback] | <code>function</code> | Optional callback |
+-   `INVALID_TRANSACTION_HASH`
+-   Fetch error
+
+| Param      | Type                            | Description                 |
+| ---------- | ------------------------------- | --------------------------- |
+| hashes     | <code>Array.&lt;Hash&gt;</code> | Array of transaction hashes |
+| [callback] | <code>function</code>           | Optional callback           |
 
 Fetches the transaction objects, given an array of transaction hashes.
 
-**Example**  
+**Example**
+
 ```js
 getTransactionObjects(hashes)
-  .then(transactions => {
-    // ...
-  })
-  .catch(err => {
-    // handle errors
-  })
+    .then(transactions => {
+        // ...
+    })
+    .catch(err => {
+        // handle errors
+    })
 ```
+
 <a name="module_core.createGetTransactionsToApprove"></a>
 
-### *core*.createGetTransactionsToApprove(provider)
+### _core_.createGetTransactionsToApprove(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`getTransactionsToApprove`](#module_core.getTransactionsToApprove)  
 <a name="module_core.getTransactionsToApprove"></a>
 
-### *core*.getTransactionsToApprove(depth, [reference], [callback])
+### _core_.getTransactionsToApprove(depth, [reference], [callback])
+
 **Fulfil**: <code>trunkTransaction, branchTransaction</code> A pair of approved transactions  
 **Reject**: <code>Error</code>
-- `INVALID_DEPTH`
-- `INVALID_REFERENCE_HASH`: Invalid reference hash
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| depth | <code>number</code> | The depth at which Random Walk starts. A value of `3` is typically used by wallets, meaning that RW starts 3 milestones back. |
-| [reference] | <code>Hash</code> | Optional reference transaction hash |
-| [callback] | <code>Callback</code> | Optional callback |
+-   `INVALID_DEPTH`
+-   `INVALID_REFERENCE_HASH`: Invalid reference hash
+-   Fetch error
+
+| Param       | Type                  | Description                                                                                                                   |
+| ----------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| depth       | <code>number</code>   | The depth at which Random Walk starts. A value of `3` is typically used by wallets, meaning that RW starts 3 milestones back. |
+| [reference] | <code>Hash</code>     | Optional reference transaction hash                                                                                           |
+| [callback]  | <code>Callback</code> | Optional callback                                                                                                             |
 
 Does the _tip selection_ by calling
 [`getTransactionsToApprove`](https://docs.iota.works/iri/api#endpoints/getTransactionsToApprove) command.
@@ -944,87 +1013,94 @@ The `reference` option allows to select tips in a way that the reference transac
 This is useful for promoting transactions, for example with
 [`promoteTransaction`](#module_core.promoteTransaction).
 
-**Example**  
+**Example**
+
 ```js
 const depth = 3
 const minWeightMagnitude = 14
 
 getTransactionsToApprove(depth)
-  .then(transactionsToApprove =>
-     attachToTanle(minWightMagnitude, trytes, { transactionsToApprove })
-  )
-  .then(storeAndBroadcast)
-  .catch(err => {
-    // handle errors here
-  })
+    .then(transactionsToApprove => attachToTanle(minWightMagnitude, trytes, { transactionsToApprove }))
+    .then(storeAndBroadcast)
+    .catch(err => {
+        // handle errors here
+    })
 ```
+
 <a name="module_core.createGetTrytes"></a>
 
-### *core*.createGetTrytes(provider)
+### _core_.createGetTrytes(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`getTrytes`](#module_core.getTrytes)  
 <a name="module_core.getTrytes"></a>
 
-### *core*.getTrytes(hashes, [callback])
+### _core_.getTrytes(hashes, [callback])
+
 **Fulfil**: <code>Trytes[]</code> - Transaction trytes  
 **Reject**: Error{}
-- `INVALID_TRANSACTION_HASH`: Invalid hash
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| hashes | <code>Array.&lt;Hash&gt;</code> | List of transaction hashes |
-| [callback] | <code>Callback</code> | Optional callback |
+-   `INVALID_TRANSACTION_HASH`: Invalid hash
+-   Fetch error
+
+| Param      | Type                            | Description                |
+| ---------- | ------------------------------- | -------------------------- |
+| hashes     | <code>Array.&lt;Hash&gt;</code> | List of transaction hashes |
+| [callback] | <code>Callback</code>           | Optional callback          |
 
 Fetches the transaction trytes given a list of transaction hashes, by calling
 [`getTrytes`](https://docs.iota.works/iri/api#endpoints/getTrytes) command.
 
-**Example**  
+**Example**
+
 ```js
 getTrytes(hashes)
-  // Parsing as transaction objects
-  .then(trytes => asTransactionObjects(hashes)(trytes))
-  .then(transactions => {
-    // ...
-  })
-  .catch(err => {
-    // ...
-  })
+    // Parsing as transaction objects
+    .then(trytes => asTransactionObjects(hashes)(trytes))
+    .then(transactions => {
+        // ...
+    })
+    .catch(err => {
+        // ...
+    })
 ```
+
 <a name="module_core.createIsPromotable"></a>
 
-### *core*.createIsPromotable(provider, [depth])
+### _core_.createIsPromotable(provider, [depth])
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| provider | <code>Provider</code> |  | Network provider |
-| [depth] | <code>number</code> | <code>6</code> | Depth up to which promotion is effective. |
+| Param    | Type                  | Default        | Description                               |
+| -------- | --------------------- | -------------- | ----------------------------------------- |
+| provider | <code>Provider</code> |                | Network provider                          |
+| [depth]  | <code>number</code>   | <code>6</code> | Depth up to which promotion is effective. |
 
 **Returns**: <code>function</code> - [`isPromotable`](#module_core.isPromotable)  
 <a name="module_core.isPromotable"></a>
 
-### *core*.isPromotable(tail, [callback])
+### _core_.isPromotable(tail, [callback])
+
 **Fulfil**: <code>boolean</code> Consistency state of transaction or co-consistency of transactions  
 **Reject**: <code>Error</code>
-- `INVALID_HASH`: Invalid hash
-- `INVALID_DEPTH`: Invalid depth
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| tail | <code>Hash</code> | Tail transaction hash |
-| [callback] | <code>Callback</code> | Optional callback |
+-   `INVALID_HASH`: Invalid hash
+-   `INVALID_DEPTH`: Invalid depth
+-   Fetch error
+
+| Param      | Type                  | Description           |
+| ---------- | --------------------- | --------------------- |
+| tail       | <code>Hash</code>     | Tail transaction hash |
+| [callback] | <code>Callback</code> | Optional callback     |
 
 Checks if a transaction is _promotable_, by calling [`checkConsistency`](#module_core.checkConsistency) and
 verifying that `attachmentTimestamp` is above a lower bound.
 Lower bound is calculated based on number of milestones issued
 since transaction attachment.
 
-**Example**  
+**Example**
+
 #### Example with promotion and reattachments
 
 Using `isPromotable` to determine if transaction can be [_promoted_](#module_core.promoteTransaction)
@@ -1057,12 +1133,13 @@ getLatestInclusion(tails)
     // ...
   })
 ```
+
 <a name="module_core.createPrepareTransfers"></a>
 
-### *core*.createPrepareTransfers([provider])
+### _core_.createPrepareTransfers([provider])
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param      | Type                  | Description                                                                                                                                                                                                        |
+| ---------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [provider] | <code>Provider</code> | Optional network provider to fetch inputs and remainder address. In case this is omitted, proper input objects and remainder should be passed to [`prepareTransfers`](#module_core.prepareTransfers), if required. |
 
 Create a [`prepareTransfers`](#module_core.prepareTransfers) function by passing an optional newtowrk `provider`.
@@ -1071,36 +1148,38 @@ It is possible to prepare and sign transactions offline, by omitting the provide
 **Returns**: <code>function</code> - [`prepareTransfers`](#module_core.prepareTransfers)  
 <a name="module_core.prepareTransfers"></a>
 
-### *core*.prepareTransfers(seed, transfers, [options], [callback])
+### _core_.prepareTransfers(seed, transfers, [options], [callback])
+
 **Fulfil**: <code>array</code> trytes Returns bundle trytes  
 **Reject**: <code>Error</code>
-- `INVALID_SEED`
-- `INVALID_TRANSFER_ARRAY`
-- `INVALID_INPUT`
-- `INVALID_REMAINDER_ADDRESS`
-- `INSUFFICIENT_BALANCE`
-- `NO_INPUTS`
-- `SENDING_BACK_TO_INPUTS`
-- Fetch error, if connected to network  
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| seed | <code>string</code> |  |  |
-| transfers | <code>object</code> |  |  |
-| [options] | <code>object</code> |  |  |
-| [options.inputs] | <code>Array.&lt;Input&gt;</code> |  | Inputs used for signing. Needs to have correct security, keyIndex and address value |
-| [options.inputs[].address] | <code>Hash</code> |  | Input address trytes |
-| [options.inputs[].keyIndex] | <code>number</code> |  | Key index at which address was generated |
-| [options.inputs[].security] | <code>number</code> | <code>2</code> | Security level |
-| [options.inputs[].balance] | <code>number</code> |  | Balance in iotas |
-| [options.address] | <code>Hash</code> |  | Remainder address |
-| [options.security] | <code>Number</code> |  | Security level to be used for getting inputs and reminder address |
-| [callback] | <code>function</code> |  | Optional callback |
+-   `INVALID_SEED`
+-   `INVALID_TRANSFER_ARRAY`
+-   `INVALID_INPUT`
+-   `INVALID_REMAINDER_ADDRESS`
+-   `INSUFFICIENT_BALANCE`
+-   `NO_INPUTS`
+-   `SENDING_BACK_TO_INPUTS`
+-   Fetch error, if connected to network
+
+| Param                       | Type                             | Default        | Description                                                                         |
+| --------------------------- | -------------------------------- | -------------- | ----------------------------------------------------------------------------------- |
+| seed                        | <code>string</code>              |                |                                                                                     |
+| transfers                   | <code>object</code>              |                |                                                                                     |
+| [options]                   | <code>object</code>              |                |                                                                                     |
+| [options.inputs]            | <code>Array.&lt;Input&gt;</code> |                | Inputs used for signing. Needs to have correct security, keyIndex and address value |
+| [options.inputs[].address]  | <code>Hash</code>                |                | Input address trytes                                                                |
+| [options.inputs[].keyIndex] | <code>number</code>              |                | Key index at which address was generated                                            |
+| [options.inputs[].security] | <code>number</code>              | <code>2</code> | Security level                                                                      |
+| [options.inputs[].balance]  | <code>number</code>              |                | Balance in iotas                                                                    |
+| [options.address]           | <code>Hash</code>                |                | Remainder address                                                                   |
+| [options.security]          | <code>Number</code>              |                | Security level to be used for getting inputs and reminder address                   |
+| [callback]                  | <code>function</code>            |                | Optional callback                                                                   |
 
 **Properties**
 
-| Name | Type | Description |
-| --- | --- | --- |
+| Name              | Type              | Description                         |
+| ----------------- | ----------------- | ----------------------------------- |
 | [options.hmacKey] | <code>Hash</code> | HMAC key used for attaching an HMAC |
 
 Prepares the transaction trytes by generating a bundle, filling in transfers and inputs,
@@ -1113,32 +1192,34 @@ This will allow for reattachments and prevent key reuse if trytes can't be recov
 
 <a name="module_core.createPromoteTransaction"></a>
 
-### *core*.createPromoteTransaction(provider, [attachFn])
+### _core_.createPromoteTransaction(provider, [attachFn])
 
-| Param | Type | Description |
-| --- | --- | --- |
-| provider | <code>Provider</code> | Network provider |
+| Param      | Type                  | Description                                                                                       |
+| ---------- | --------------------- | ------------------------------------------------------------------------------------------------- |
+| provider   | <code>Provider</code> | Network provider                                                                                  |
 | [attachFn] | <code>function</code> | Optional `AttachToTangle` function to override the [default method](#module_core.attachToTangle). |
 
 **Returns**: <code>function</code> - [`promoteTransaction`](#module_core.promoteTransaction)  
 <a name="module_core.promoteTransaction"></a>
 
-### *core*.promoteTransaction(tail, depth, minWeightMagnitude, transfer, [options], [callback])
+### _core_.promoteTransaction(tail, depth, minWeightMagnitude, transfer, [options], [callback])
+
 **Fulfil**: <code>Transaction[]</code>  
 **Reject**: <code>Error</code>
-- `INCONSISTENT SUBTANGLE`: In this case promotion has no effect and reatchment is required.
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| tail | <code>string</code> |  |
-| depth | <code>int</code> |  |
-| minWeightMagnitude | <code>int</code> |  |
-| transfer | <code>array</code> |  |
-| [options] | <code>object</code> |  |
-| [options.delay] | <code>number</code> | Delay between spam transactions in `ms` |
+-   `INCONSISTENT SUBTANGLE`: In this case promotion has no effect and reatchment is required.
+-   Fetch error
+
+| Param               | Type                                          | Description                                                         |
+| ------------------- | --------------------------------------------- | ------------------------------------------------------------------- |
+| tail                | <code>string</code>                           |                                                                     |
+| depth               | <code>int</code>                              |                                                                     |
+| minWeightMagnitude  | <code>int</code>                              |                                                                     |
+| transfer            | <code>array</code>                            |                                                                     |
+| [options]           | <code>object</code>                           |                                                                     |
+| [options.delay]     | <code>number</code>                           | Delay between spam transactions in `ms`                             |
 | [options.interrupt] | <code>boolean</code> \| <code>function</code> | Interrupt signal, which can be a function that evaluates to boolean |
-| [callback] | <code>function</code> |  |
+| [callback]          | <code>function</code>                         |                                                                     |
 
 Promotes a transaction by adding other transactions (spam by default) on top of it.
 Will promote `maximum` transfers on top of the current one with `delay` interval. Promotion
@@ -1146,24 +1227,26 @@ is interruptable through `interrupt` option.
 
 <a name="module_core.createRemoveNeighbors"></a>
 
-### *core*.createRemoveNeighbors(provider)
+### _core_.createRemoveNeighbors(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`removeNeighbors`](#module_core.removeNeighbors)  
 <a name="module_core.removeNeighbors"></a>
 
-### *core*.removeNeighbors(uris, [callback])
+### _core_.removeNeighbors(uris, [callback])
+
 **Fulfil**: <code>number</code> Number of neighbors that were removed  
 **Reject**: <code>Error</code>
-- `INVALID_URI`: Invalid uri
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| uris | <code>Array</code> | List of URI's |
+-   `INVALID_URI`: Invalid uri
+-   Fetch error
+
+| Param      | Type                  | Description       |
+| ---------- | --------------------- | ----------------- |
+| uris       | <code>Array</code>    | List of URI's     |
 | [callback] | <code>Callback</code> | Optional callback |
 
 Removes a list of neighbors from the connected IRI node by calling
@@ -1174,36 +1257,39 @@ This method has temporary effect until your IRI node relaunches.
 
 <a name="module_core.createReplayBundle"></a>
 
-### *core*.createReplayBundle(provider)
+### _core_.createReplayBundle(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`replayBundle`](#module_core.replayBundle)  
 <a name="module_core.replayBundle"></a>
 
-### *core*.replayBundle(tail, depth, minWeightMagnitude, [callback])
+### _core_.replayBundle(tail, depth, minWeightMagnitude, [callback])
+
 **Fulfil**: <code>Transaction[]</code>  
 **Reject**: <code>Error</code>
-- `INVALID_DEPTH`
-- `INVALID_MIN_WEIGHT_MAGNITUDE`
-- `INVALID_TRANSACTION_HASH`
-- `INVALID_BUNDLE`
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| tail | <code>Hash</code> | Tail transaction hash. Tail transaction is the transaction in the bundle with `currentIndex == 0`. |
-| depth | <code>number</code> | The depth at which Random Walk starts. A value of `3` is typically used by wallets, meaning that RW starts 3 milestones back. |
-| minWeightMagnitude | <code>number</code> | Minimum number of trailing zeros in transaction hash. This is used by [`attachToTangle`](#module_core.attachToTangle) function to search for a valid `nonce`. Currently is `14` on mainnet & spamnnet and `9` on most other testnets. |
-| [callback] | <code>Callback</code> | Optional callback |
+-   `INVALID_DEPTH`
+-   `INVALID_MIN_WEIGHT_MAGNITUDE`
+-   `INVALID_TRANSACTION_HASH`
+-   `INVALID_BUNDLE`
+-   Fetch error
+
+| Param              | Type                  | Description                                                                                                                                                                                                                           |
+| ------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| tail               | <code>Hash</code>     | Tail transaction hash. Tail transaction is the transaction in the bundle with `currentIndex == 0`.                                                                                                                                    |
+| depth              | <code>number</code>   | The depth at which Random Walk starts. A value of `3` is typically used by wallets, meaning that RW starts 3 milestones back.                                                                                                         |
+| minWeightMagnitude | <code>number</code>   | Minimum number of trailing zeros in transaction hash. This is used by [`attachToTangle`](#module_core.attachToTangle) function to search for a valid `nonce`. Currently is `14` on mainnet & spamnnet and `9` on most other testnets. |
+| [callback]         | <code>Callback</code> | Optional callback                                                                                                                                                                                                                     |
 
 Reattaches a transfer to tangle by selecting tips & performing the Proof-of-Work again.
 Reattachments are usefull in case original transactions are pending, and can be done securely
 as many times as needed.
 
-**Example**  
+**Example**
+
 ```js
 replayBundle(tail)
   .then(transactions => {
@@ -1214,108 +1300,117 @@ replayBundle(tail)
   })
 })
 ```
+
 <a name="module_core.createSendTrytes"></a>
 
-### *core*.createSendTrytes(provider)
+### _core_.createSendTrytes(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`sendTrytes`](#module_core.sendTrytes)  
 <a name="module_core.sendTrytes"></a>
 
-### *core*.sendTrytes(trytes, depth, minWeightMagnitude, [reference], [callback])
-**Fulfil**: <code>Transaction[]</code>  Returns list of attached transactions  
-**Reject**: <code>Error</code>
-- `INVALID_TRANSACTION_TRYTES`
-- `INVALID_DEPTH`
-- `INVALID_MIN_WEIGHT_MAGNITUDE`
-- Fetch error, if connected to network  
+### _core_.sendTrytes(trytes, depth, minWeightMagnitude, [reference], [callback])
 
-| Param | Type | Description |
-| --- | --- | --- |
-| trytes | <code>Array.&lt;Trytes&gt;</code> | List of trytes to attach, store & broadcast |
-| depth | <code>number</code> | Depth |
-| minWeightMagnitude | <code>number</code> | Min weight magnitude |
-| [reference] | <code>string</code> | Optional reference hash |
-| [callback] | <code>Callback</code> | Optional callback |
+**Fulfil**: <code>Transaction[]</code> Returns list of attached transactions  
+**Reject**: <code>Error</code>
+
+-   `INVALID_TRANSACTION_TRYTES`
+-   `INVALID_DEPTH`
+-   `INVALID_MIN_WEIGHT_MAGNITUDE`
+-   Fetch error, if connected to network
+
+| Param              | Type                              | Description                                 |
+| ------------------ | --------------------------------- | ------------------------------------------- |
+| trytes             | <code>Array.&lt;Trytes&gt;</code> | List of trytes to attach, store & broadcast |
+| depth              | <code>number</code>               | Depth                                       |
+| minWeightMagnitude | <code>number</code>               | Min weight magnitude                        |
+| [reference]        | <code>string</code>               | Optional reference hash                     |
+| [callback]         | <code>Callback</code>             | Optional callback                           |
 
 [Attaches to tanlge](#module_core.attachToTangle), [stores](#module_core.storeTransactions)
 and [broadcasts](#module_core.broadcastTransactions) a list of transaction trytes.
 
-**Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
+**Note:** Persist the transaction trytes in local storage **before** calling this command, to ensure
 that reattachment is possible, until your bundle has been included.
 
-**Example**  
+**Example**
+
 ```js
 prepareTransfers(seed, transfers)
-  .then(trytes => {
-     // Persist trytes locally before sending to network.
-     // This allows for reattachments and prevents key reuse if trytes can't
-     // be recovered by querying the network after broadcasting.
+    .then(trytes => {
+        // Persist trytes locally before sending to network.
+        // This allows for reattachments and prevents key reuse if trytes can't
+        // be recovered by querying the network after broadcasting.
 
-     return iota.sendTrytes(trytes, depth, minWeightMagnitude)
-  })
-  .then(transactions => {
-    // ...
-  })
-  .catch(err => {
-    // ...
-  })
+        return iota.sendTrytes(trytes, depth, minWeightMagnitude)
+    })
+    .then(transactions => {
+        // ...
+    })
+    .catch(err => {
+        // ...
+    })
 ```
+
 <a name="module_core.createStoreAndBroadcast"></a>
 
-### *core*.createStoreAndBroadcast(provider)
+### _core_.createStoreAndBroadcast(provider)
 
-| Param | Type |
-| --- | --- |
-| provider | <code>Provider</code> | 
+| Param    | Type                  |
+| -------- | --------------------- |
+| provider | <code>Provider</code> |
 
 **Returns**: <code>function</code> - [`storeAndBroadcast`](#module_core.storeAndBroadcast)  
 <a name="module_core.storeAndBroadcast"></a>
 
-### *core*.storeAndBroadcast(trytes, [callback])
+### _core_.storeAndBroadcast(trytes, [callback])
+
 **Fulfil**: <code>Trytes[]</code> Attached transaction trytes  
 **Reject**: <code>Error</code>
-- `INVALID_ATTACHED_TRYTES`: Invalid attached trytes
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| trytes | <code>Array.&lt;Trytes&gt;</code> | Attached transaction trytes |
-| [callback] | <code>Callback</code> | Optional callback |
+-   `INVALID_ATTACHED_TRYTES`: Invalid attached trytes
+-   Fetch error
+
+| Param      | Type                              | Description                 |
+| ---------- | --------------------------------- | --------------------------- |
+| trytes     | <code>Array.&lt;Trytes&gt;</code> | Attached transaction trytes |
+| [callback] | <code>Callback</code>             | Optional callback           |
 
 Stores and broadcasts a list of _attached_ transaction trytes by calling
 [`storeTransactions`](#module_core.storeTransactions) and
 [`broadcastTransactions`](#module_core.broadcastTransactions).
 
-**Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
+**Note:** Persist the transaction trytes in local storage **before** calling this command, to ensure
 that reattachment is possible, until your bundle has been included.
 
 Any transactions stored with this command will eventaully be erased, as a result of a snapshot.
 
 <a name="module_core.createStoreTransactions"></a>
 
-### *core*.createStoreTransactions(provider)
+### _core_.createStoreTransactions(provider)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param    | Type                  | Description      |
+| -------- | --------------------- | ---------------- |
 | provider | <code>Provider</code> | Network provider |
 
 **Returns**: <code>function</code> - [`storeTransactions`](#module_core.storeTransactions)  
 <a name="module_core.storeTransactions"></a>
 
-### *core*.storeTransactions(trytes, [callback])
+### _core_.storeTransactions(trytes, [callback])
+
 **Fullfil**: <code>Trytes[]</code> Attached transaction trytes  
 **Reject**: <code>Error</code>
-- `INVALID_ATTACHED_TRYTES`: Invalid attached trytes
-- Fetch error  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| trytes | <code>Array.&lt;Trytes&gt;</code> | Attached transaction trytes |
-| [callback] | <code>Callback</code> | Optional callback |
+-   `INVALID_ATTACHED_TRYTES`: Invalid attached trytes
+-   Fetch error
+
+| Param      | Type                              | Description                 |
+| ---------- | --------------------------------- | --------------------------- |
+| trytes     | <code>Array.&lt;Trytes&gt;</code> | Attached transaction trytes |
+| [callback] | <code>Callback</code>             | Optional callback           |
 
 Persists a list of _attached_ transaction trytes in the store of connected node by calling
 [`storeTransactions`](https://docs.iota.org/iri/api#endpoints/storeTransactions) command.
@@ -1324,60 +1419,64 @@ Tip selection and Proof-of-Work must be done first, by calling
 [`attachToTangle`](#module_core.attachToTangle) or an equivalent attach method or remote
 [`PoWbox`](https://powbox.devnet.iota.org/).
 
-**Note:** Persist the transaction trytes in local storage __before__ calling this command, to ensure
+**Note:** Persist the transaction trytes in local storage **before** calling this command, to ensure
 that reattachment is possible, until your bundle has been included.
 
 Any transactions stored with this command will eventaully be erased, as a result of a snapshot.
 
 <a name="module_core.createTraverseBundle"></a>
 
-### *core*.createTraverseBundle(provider)
+### _core_.createTraverseBundle(provider)
 
-| Param | Type |
-| --- | --- |
-| provider | <code>Provider</code> | 
+| Param    | Type                  |
+| -------- | --------------------- |
+| provider | <code>Provider</code> |
 
 **Returns**: <code>function</code> - [`traverseBundle`](#module_core.traverseBundle)  
 <a name="module_core.traverseBundle"></a>
 
-### *core*.traverseBundle(trunkTransaction, [bundle], [callback])
+### _core_.traverseBundle(trunkTransaction, [bundle], [callback])
+
 **Fulfil**: <code>Transaction[]</code> Bundle as array of transaction objects  
 **Reject**: <code>Error</code>
-- `INVALID_TRANSACTION_HASH`
-- `INVALID_TAIL_HASH`: Provided transaction is not tail (`currentIndex !== 0`)
-- `INVALID_BUNDLE`: Bundle is syntactically invalid
-- Fetch error  
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| trunkTransaction | <code>Hash</code> |  | Trunk transaction, should be tail (`currentIndex == 0`) |
-| [bundle] | <code>Hash</code> | <code>[]</code> | List of accumulated transactions |
-| [callback] | <code>Callback</code> |  | Optional callback |
+-   `INVALID_TRANSACTION_HASH`
+-   `INVALID_TAIL_HASH`: Provided transaction is not tail (`currentIndex !== 0`)
+-   `INVALID_BUNDLE`: Bundle is syntactically invalid
+-   Fetch error
+
+| Param            | Type                  | Default         | Description                                             |
+| ---------------- | --------------------- | --------------- | ------------------------------------------------------- |
+| trunkTransaction | <code>Hash</code>     |                 | Trunk transaction, should be tail (`currentIndex == 0`) |
+| [bundle]         | <code>Hash</code>     | <code>[]</code> | List of accumulated transactions                        |
+| [callback]       | <code>Callback</code> |                 | Optional callback                                       |
 
 Fetches the bundle of a given the _tail_ transaction hash, by traversing through `trunkTransaction`.
 It does not validate the bundle.
 
-**Example**  
+**Example**
+
 ```js
 traverseBundle(tail)
-   .then(bundle => {
-       // ...
-   })
-   .catch(err => {
-       // handle errors
-   })
+    .then(bundle => {
+        // ...
+    })
+    .catch(err => {
+        // handle errors
+    })
 ```
+
 <a name="module_core.generateAddress"></a>
 
-### *core*.generateAddress(seed, index, [security], [checksum])
+### _core_.generateAddress(seed, index, [security], [checksum])
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| seed | <code>string</code> |  |  |
-| index | <code>number</code> |  | Private key index |
-| [security] | <code>number</code> | <code>2</code> | Security level of the private key |
-| [checksum] | <code>boolean</code> | <code>false</code> | Flag to add 9trytes checksum |
+| Param      | Type                 | Default            | Description                       |
+| ---------- | -------------------- | ------------------ | --------------------------------- |
+| seed       | <code>string</code>  |                    |                                   |
+| index      | <code>number</code>  |                    | Private key index                 |
+| [security] | <code>number</code>  | <code>2</code>     | Security level of the private key |
+| [checksum] | <code>boolean</code> | <code>false</code> | Flag to add 9trytes checksum      |
 
 Generates an address deterministically, according to the given seed, index and security level.
 
-**Returns**: <code>Hash</code> - Address trytes  
+**Returns**: <code>Hash</code> - Address trytes

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@iota/core",
-    "version": "1.0.0-beta.5",
+    "version": "1.0.0-beta.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/packages/core/src/composeAPI.ts
+++ b/packages/core/src/composeAPI.ts
@@ -80,7 +80,7 @@ export function returnType<T>(func: Func<T>) {
  * @memberof module:core
  *
  * @param {object} [settings={}] - Connection settings
- * @param {Provider} [settings.network] - Network provider defaults to `http-client`.
+ * @param {Provider} [settings.network] - Network provider, defaults to `http-client`.
  * @param {string} [settings.provider=http://localhost:14265] Uri of IRI node
  * @param {function} [settings.attachToTangle] - Function to override
  * [`attachToTangle`]{@link #module_core.attachToTangle} with

--- a/packages/core/src/composeAPI.ts
+++ b/packages/core/src/composeAPI.ts
@@ -3,7 +3,6 @@ import * as Bluebird from 'bluebird' // tslint:disable-line no-unused-variable
 import {
     AttachToTangle,
     BaseCommand, // tslint:disable-line no-unused-variable
-    CreateProvider,
     Inputs, // tslint:disable-line no-unused-variable
     Neighbor, // tslint:disable-line no-unused-variable
     Provider, // tslint:disable-line no-unused-variable
@@ -63,6 +62,7 @@ import {
 } from './createGetTransfers'
 
 export interface Settings extends HttpClientSettings {
+    readonly network?: Provider
     readonly attachToTangle?: AttachToTangle
 }
 
@@ -80,6 +80,7 @@ export function returnType<T>(func: Func<T>) {
  * @memberof module:core
  *
  * @param {object} [settings={}] - Connection settings
+ * @param {Provider} [settings.network] - Network provider defaults to `http-client`.
  * @param {string} [settings.provider=http://localhost:14265] Uri of IRI node
  * @param {function} [settings.attachToTangle] - Function to override
  * [`attachToTangle`]{@link #module_core.attachToTangle} with
@@ -101,15 +102,24 @@ export const composeAPI = (settings: Partial<Settings> = {}) => {
      *
      * @param {object} settings - Provider settings object
      * @param {string} [settings.provider] - Http `uri` of IRI node
-     * @param {function} [settings.attachToTangle] - Function to override
+     * @param {Provider} [settings.network] - Network provider to override with
+     * @param {function} [settings.attachToTangle] - AttachToTangle function to override with
      * [`attachToTangle`]{@link #module_core.attachToTangle} with
      */
     function setSettings(newSettings: Partial<Settings> = {}) {
-        provider.setSettings(newSettings)
-
         if (newSettings.attachToTangle) {
             attachToTangle = newSettings.attachToTangle
         }
+
+        if (newSettings.network) {
+            provider = newSettings.network
+        }
+
+        provider.setSettings(newSettings)
+    }
+
+    function overrideNetwork(network: Provider) {
+        provider = network
     }
 
     /**
@@ -170,6 +180,7 @@ export const composeAPI = (settings: Partial<Settings> = {}) => {
         traverseBundle: createTraverseBundle(provider),
         setSettings,
         overrideAttachToTangle,
+        overrideNetwork,
     }
 }
 

--- a/packages/core/src/composeAPI.ts
+++ b/packages/core/src/composeAPI.ts
@@ -79,7 +79,7 @@ export function returnType<T>(func: Func<T>) {
  *
  * @memberof module:core
  *
- * @param {object | Function} [settings={} | provider] - Connection settings or `provider` factory
+ * @param {object} [settings={}] - Connection settings
  * @param {string} [settings.provider=http://localhost:14265] Uri of IRI node
  * @param {function} [settings.attachToTangle] - Function to override
  * [`attachToTangle`]{@link #module_core.attachToTangle} with
@@ -88,11 +88,8 @@ export function returnType<T>(func: Func<T>) {
  *
  * @return {API}
  */
-export const composeAPI = (input: Partial<Settings> | CreateProvider = {}) => {
-    const isFn = typeof input === 'function'
-    const settings: Partial<Settings> = isFn ? {} : (input as Partial<Settings>)
-    const provider: Provider = isFn ? (input as CreateProvider)() : createHttpClient(settings)
-
+export const composeAPI = (settings: Partial<Settings> = {}) => {
+    let provider: Provider = createHttpClient(settings)
     let attachToTangle: AttachToTangle = settings.attachToTangle || createAttachToTangle(provider)
 
     /**
@@ -131,7 +128,7 @@ export const composeAPI = (input: Partial<Settings> | CreateProvider = {}) => {
     }
 
     /** @namespace API */
-    const api = {
+    return {
         // IRI commands
         addNeighbors: createAddNeighbors(provider),
         attachToTangle,
@@ -174,13 +171,6 @@ export const composeAPI = (input: Partial<Settings> | CreateProvider = {}) => {
         setSettings,
         overrideAttachToTangle,
     }
-
-    return isFn
-        ? (settingsB: Partial<Settings>) => {
-              setSettings(settingsB)
-              return api
-          }
-        : api
 }
 
 export const apiType = returnType(composeAPI)

--- a/packages/core/test/integration/composeAPI.test.ts
+++ b/packages/core/test/integration/composeAPI.test.ts
@@ -3,13 +3,15 @@ import test from 'ava'
 import { API, composeAPI } from '../../src'
 import { getNodeInfoResponse } from './nocks/getNodeInfo'
 
-test.todo(
-    'composeAPI() composes API with network provider as argument' /*async t => {
+test('composeAPI() composes API with network provider as argument', async t => {
     const api: API = composeAPI({ network: createHttpClient() })
 
-    t.deepEqual(await api.getNodeInfo(), getNodeInfoResponse, 'composeAPI() should compose API with provider factory')
-}*/
-)
+    t.deepEqual(
+        await api.getNodeInfo(),
+        getNodeInfoResponse,
+        'composeAPI() should compose API with network provider as argument'
+    )
+})
 
 test('composeAPI() composes API with default provider', async t => {
     const api: any = composeAPI()

--- a/packages/core/test/integration/composeAPI.test.ts
+++ b/packages/core/test/integration/composeAPI.test.ts
@@ -3,11 +3,13 @@ import test from 'ava'
 import { API, composeAPI } from '../../src'
 import { getNodeInfoResponse } from './nocks/getNodeInfo'
 
-test('composeAPI() composes API with provider factory', async t => {
-    const api: any = (composeAPI(createHttpClient) as (s?: Partial<object>) => API)()
+test.todo(
+    'composeAPI() composes API with network provider as argument' /*async t => {
+    const api: API = composeAPI({ network: createHttpClient() })
 
     t.deepEqual(await api.getNodeInfo(), getNodeInfoResponse, 'composeAPI() should compose API with provider factory')
-})
+}*/
+)
 
 test('composeAPI() composes API with default provider', async t => {
     const api: any = composeAPI()

--- a/packages/http-client/package-lock.json
+++ b/packages/http-client/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@iota/http-client",
-    "version": "1.0.0-beta.5",
+    "version": "1.0.0-beta.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -12,8 +12,7 @@
         "@types/nock": {
             "version": "9.1.3",
             "resolved": "https://registry.npmjs.org/@types/nock/-/nock-9.1.3.tgz",
-            "integrity":
-                "sha512-S8rJ+SaW82ICX87pZP62UcMifrMfjEdqNzSp+llx4YcvKw6bO650Ye6HwTqER1Dar3S40GIZECQisOrAICDCjA==",
+            "integrity": "sha512-S8rJ+SaW82ICX87pZP62UcMifrMfjEdqNzSp+llx4YcvKw6bO650Ye6HwTqER1Dar3S40GIZECQisOrAICDCjA==",
             "dev": true,
             "requires": {
                 "@types/node": "*"
@@ -22,15 +21,13 @@
         "@types/node": {
             "version": "10.5.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.1.tgz",
-            "integrity":
-                "sha512-AFLl1IALIuyt6oK4AYZsgWVJ/5rnyzQWud7IebaZWWV3YmgtPZkQmYio9R5Ze/2pdd7XfqF5bP+hWS11mAKoOQ==",
+            "integrity": "sha512-AFLl1IALIuyt6oK4AYZsgWVJ/5rnyzQWud7IebaZWWV3YmgtPZkQmYio9R5Ze/2pdd7XfqF5bP+hWS11mAKoOQ==",
             "dev": true
         },
         "assertion-error": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-            "integrity":
-                "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
             "dev": true
         },
         "bluebird": {
@@ -74,21 +71,10 @@
                 }
             }
         },
-        "debug": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity":
-                "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-            "dev": true,
-            "requires": {
-                "ms": "^2.1.1"
-            }
-        },
         "deep-eql": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-            "integrity":
-                "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+            "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
             "dev": true,
             "requires": {
                 "type-detect": "^4.0.0"
@@ -100,41 +86,11 @@
             "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
             "dev": true
         },
-        "encoding": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-            "requires": {
-                "iconv-lite": "~0.4.13"
-            }
-        },
         "get-func-name": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
             "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
             "dev": true
-        },
-        "iconv-lite": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-            "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-            "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            }
-        },
-        "is-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        },
-        "isomorphic-fetch": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-            "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-            "requires": {
-                "node-fetch": "^1.0.1",
-                "whatwg-fetch": ">=0.10.0"
-            }
         },
         "json-stringify-safe": {
             "version": "5.0.1",
@@ -184,6 +140,17 @@
                 "propagate": "^1.0.0",
                 "qs": "^6.5.1",
                 "semver": "^5.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+                    "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
             }
         },
         "pathval": {
@@ -204,11 +171,6 @@
             "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
             "dev": true
         },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
         "semver": {
             "version": "5.6.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -218,8 +180,7 @@
         "type-detect": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-            "integrity":
-                "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
             "dev": true
         },
         "whatwg-fetch": {

--- a/packages/http-client/src/httpClient.ts
+++ b/packages/http-client/src/httpClient.ts
@@ -3,7 +3,6 @@
 import * as Promise from 'bluebird'
 import {
     BaseCommand,
-    CreateProvider,
     FindTransactionsCommand,
     GetBalancesCommand,
     GetInclusionStatesCommand,
@@ -67,7 +66,7 @@ export const getKeysToBatch = <C>(
  * @param {number} [settings.requestBatchSize=1000] - Number of search values per request.
  * @return Object
  */
-export const createHttpClient: CreateProvider = (settings?: Partial<Settings>): Provider => {
+export const createHttpClient = (settings?: Partial<Settings>): Provider => {
     let currentSettings = getSettingsWithDefaults({ ...settings })
     return {
         /**

--- a/packages/kerl/package-lock.json
+++ b/packages/kerl/package-lock.json
@@ -1,12 +1,13 @@
 {
-    "requires": true,
+    "name": "@iota/kerl",
+    "version": "1.0.0-beta.6",
     "lockfileVersion": 1,
+    "requires": true,
     "dependencies": {
         "@types/crypto-js": {
             "version": "3.1.41",
             "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-3.1.41.tgz",
-            "integrity":
-                "sha512-rIqkxKg9x7o8wFjeOTbkfqWd5hgyHhwqude+epWlF4N0PU5UYfSo6xyC50CgB+bk44zcNYXb4W1CQbDtcI9U5w=="
+            "integrity": "sha512-rIqkxKg9x7o8wFjeOTbkfqWd5hgyHhwqude+epWlF4N0PU5UYfSo6xyC50CgB+bk44zcNYXb4W1CQbDtcI9U5w=="
         },
         "crypto-js": {
             "version": "3.1.9-1",

--- a/packages/multisig/package-lock.json
+++ b/packages/multisig/package-lock.json
@@ -1,18 +1,18 @@
 {
-    "requires": true,
+    "name": "@iota/multisig",
+    "version": "1.0.0-beta.6",
     "lockfileVersion": 1,
+    "requires": true,
     "dependencies": {
         "@types/bluebird": {
             "version": "3.5.21",
             "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.21.tgz",
-            "integrity":
-                "sha512-6UNEwyw+6SGMC/WMI0ld0PS4st7Qq51qgguFrFizOSpGvZiqe9iswztFSdZvwJBEhLOy2JaxNE6VC7yMAlbfyQ=="
+            "integrity": "sha512-6UNEwyw+6SGMC/WMI0ld0PS4st7Qq51qgguFrFizOSpGvZiqe9iswztFSdZvwJBEhLOy2JaxNE6VC7yMAlbfyQ=="
         },
         "bluebird": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-            "integrity":
-                "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+            "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
         },
         "encoding": {
             "version": "0.1.12",
@@ -25,8 +25,7 @@
         "iconv-lite": {
             "version": "0.4.23",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-            "integrity":
-                "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+            "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
@@ -48,8 +47,7 @@
         "node-fetch": {
             "version": "1.7.3",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-            "integrity":
-                "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+            "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
             "requires": {
                 "encoding": "^0.1.11",
                 "is-stream": "^1.0.1"
@@ -58,14 +56,12 @@
         "safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity":
-                "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "whatwg-fetch": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-            "integrity":
-                "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+            "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
         }
     }
 }

--- a/packages/pearl-diver-react-native/package-lock.json
+++ b/packages/pearl-diver-react-native/package-lock.json
@@ -1,12 +1,14 @@
 {
-    "requires": true,
+    "name": "@iota/pearl-diver-react-native",
+    "version": "1.0.0-beta.6",
     "lockfileVersion": 1,
+    "requires": true,
     "dependencies": {
         "@babel/code-frame": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-            "integrity":
-                "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "dev": true,
             "requires": {
                 "@babel/highlight": "^7.0.0"
             }
@@ -14,8 +16,8 @@
         "@babel/core": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.2.tgz",
-            "integrity":
-                "sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==",
+            "integrity": "sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
                 "@babel/generator": "^7.1.2",
@@ -36,8 +38,8 @@
                 "debug": {
                     "version": "3.2.5",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-                    "integrity":
-                        "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
                     }
@@ -45,16 +47,16 @@
                 "ms": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity":
-                        "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
                 }
             }
         },
         "@babel/generator": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.2.tgz",
-            "integrity":
-                "sha512-70A9HWLS/1RHk3Ck8tNHKxOoKQuSKocYgwDN85Pyl/RBduss6AKxUR7RIZ/lzduQMSYfWEM4DDBu6A+XGbkFig==",
+            "integrity": "sha512-70A9HWLS/1RHk3Ck8tNHKxOoKQuSKocYgwDN85Pyl/RBduss6AKxUR7RIZ/lzduQMSYfWEM4DDBu6A+XGbkFig==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.1.2",
                 "jsesc": "^2.5.1",
@@ -66,25 +68,25 @@
                 "jsesc": {
                     "version": "2.5.1",
                     "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-                    "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+                    "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+                    "dev": true
                 }
             }
         },
         "@babel/helper-annotate-as-pure": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
-            "integrity":
-                "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+            "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-builder-binary-assignment-operator-visitor": {
             "version": "7.1.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
-            "integrity":
-                "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+            "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+            "dev": true,
             "requires": {
                 "@babel/helper-explode-assignable-expression": "^7.1.0",
                 "@babel/types": "^7.0.0"
@@ -92,10 +94,9 @@
         },
         "@babel/helper-builder-react-jsx": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz",
-            "integrity":
-                "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz",
+            "integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0",
                 "esutils": "^2.0.0"
@@ -104,8 +105,8 @@
         "@babel/helper-call-delegate": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
-            "integrity":
-                "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
+            "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
+            "dev": true,
             "requires": {
                 "@babel/helper-hoist-variables": "^7.0.0",
                 "@babel/traverse": "^7.1.0",
@@ -115,8 +116,8 @@
         "@babel/helper-define-map": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
-            "integrity":
-                "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
+            "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
+            "dev": true,
             "requires": {
                 "@babel/helper-function-name": "^7.1.0",
                 "@babel/types": "^7.0.0",
@@ -125,10 +126,9 @@
         },
         "@babel/helper-explode-assignable-expression": {
             "version": "7.1.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
-            "integrity":
-                "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+            "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+            "dev": true,
             "requires": {
                 "@babel/traverse": "^7.1.0",
                 "@babel/types": "^7.0.0"
@@ -137,8 +137,8 @@
         "@babel/helper-function-name": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-            "integrity":
-                "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+            "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+            "dev": true,
             "requires": {
                 "@babel/helper-get-function-arity": "^7.0.0",
                 "@babel/template": "^7.1.0",
@@ -147,10 +147,9 @@
         },
         "@babel/helper-get-function-arity": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-            "integrity":
-                "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0"
             }
@@ -158,18 +157,17 @@
         "@babel/helper-hoist-variables": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
-            "integrity":
-                "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+            "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-member-expression-to-functions": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
-            "integrity":
-                "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+            "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0"
             }
@@ -177,18 +175,17 @@
         "@babel/helper-module-imports": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
-            "integrity":
-                "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+            "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-module-transforms": {
             "version": "7.1.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz",
-            "integrity":
-                "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz",
+            "integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
+            "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.0.0",
                 "@babel/helper-simple-access": "^7.1.0",
@@ -200,10 +197,9 @@
         },
         "@babel/helper-optimise-call-expression": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
-            "integrity":
-                "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+            "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0"
             }
@@ -211,24 +207,23 @@
         "@babel/helper-plugin-utils": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-            "integrity":
-                "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
+            "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+            "dev": true
         },
         "@babel/helper-regex": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
-            "integrity":
-                "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+            "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+            "dev": true,
             "requires": {
                 "lodash": "^4.17.10"
             }
         },
         "@babel/helper-remap-async-to-generator": {
             "version": "7.1.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
-            "integrity":
-                "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+            "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+            "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.0.0",
                 "@babel/helper-wrap-function": "^7.1.0",
@@ -240,8 +235,8 @@
         "@babel/helper-replace-supers": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz",
-            "integrity":
-                "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
+            "integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
+            "dev": true,
             "requires": {
                 "@babel/helper-member-expression-to-functions": "^7.0.0",
                 "@babel/helper-optimise-call-expression": "^7.0.0",
@@ -252,8 +247,8 @@
         "@babel/helper-simple-access": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
-            "integrity":
-                "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+            "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+            "dev": true,
             "requires": {
                 "@babel/template": "^7.1.0",
                 "@babel/types": "^7.0.0"
@@ -261,10 +256,9 @@
         },
         "@babel/helper-split-export-declaration": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-            "integrity":
-                "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+            "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0"
             }
@@ -272,8 +266,8 @@
         "@babel/helper-wrap-function": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.1.0.tgz",
-            "integrity":
-                "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
+            "integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-function-name": "^7.1.0",
                 "@babel/template": "^7.1.0",
@@ -284,8 +278,8 @@
         "@babel/helpers": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.2.tgz",
-            "integrity":
-                "sha512-Myc3pUE8eswD73aWcartxB16K6CGmHDv9KxOmD2CeOs/FaEAQodr3VYGmlvOmog60vNQ2w8QbatuahepZwrHiA==",
+            "integrity": "sha512-Myc3pUE8eswD73aWcartxB16K6CGmHDv9KxOmD2CeOs/FaEAQodr3VYGmlvOmog60vNQ2w8QbatuahepZwrHiA==",
+            "dev": true,
             "requires": {
                 "@babel/template": "^7.1.2",
                 "@babel/traverse": "^7.1.0",
@@ -295,8 +289,8 @@
         "@babel/highlight": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-            "integrity":
-                "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "dev": true,
             "requires": {
                 "chalk": "^2.0.0",
                 "esutils": "^2.0.2",
@@ -306,8 +300,8 @@
                 "ansi-styles": {
                     "version": "3.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity":
-                        "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
                     "requires": {
                         "color-convert": "^1.9.0"
                     }
@@ -315,8 +309,8 @@
                 "chalk": {
                     "version": "2.4.1",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity":
-                        "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "dev": true,
                     "requires": {
                         "ansi-styles": "^3.2.1",
                         "escape-string-regexp": "^1.0.5",
@@ -326,14 +320,14 @@
                 "js-tokens": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity":
-                        "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                    "dev": true
                 },
                 "supports-color": {
                     "version": "5.5.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity":
-                        "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
                     "requires": {
                         "has-flag": "^3.0.0"
                     }
@@ -343,24 +337,23 @@
         "@babel/parser": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.2.tgz",
-            "integrity":
-                "sha512-x5HFsW+E/nQalGMw7hu+fvPqnBeBaIr0lWJ2SG0PPL2j+Pm9lYvCrsZJGIgauPIENx0v10INIyFjmSNUD/gSqQ=="
+            "integrity": "sha512-x5HFsW+E/nQalGMw7hu+fvPqnBeBaIr0lWJ2SG0PPL2j+Pm9lYvCrsZJGIgauPIENx0v10INIyFjmSNUD/gSqQ==",
+            "dev": true
         },
         "@babel/plugin-external-helpers": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.0.0.tgz",
-            "integrity":
-                "sha512-tZKTMdhZvTy0KCEX5EGQQm1RHr7jUa36q/yax1baEA0yZapVYmu10yW7LTqijITgSq416gPVjrcexiA6y4pJlA==",
+            "integrity": "sha512-tZKTMdhZvTy0KCEX5EGQQm1RHr7jUa36q/yax1baEA0yZapVYmu10yW7LTqijITgSq416gPVjrcexiA6y4pJlA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-proposal-class-properties": {
             "version": "7.1.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz",
-            "integrity":
-                "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz",
+            "integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
+            "dev": true,
             "requires": {
                 "@babel/helper-function-name": "^7.1.0",
                 "@babel/helper-member-expression-to-functions": "^7.0.0",
@@ -372,10 +365,9 @@
         },
         "@babel/plugin-proposal-export-default-from": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.0.0.tgz",
-            "integrity":
-                "sha512-cWhkx6SyjZ4caFOanoPmDNgQCuYYTmou4QXy886JsyLTw/vhWQbop2gLKsWyyswrJkKTB7fSNxVYbP/oEsoySA==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.0.0.tgz",
+            "integrity": "sha512-cWhkx6SyjZ4caFOanoPmDNgQCuYYTmou4QXy886JsyLTw/vhWQbop2gLKsWyyswrJkKTB7fSNxVYbP/oEsoySA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/plugin-syntax-export-default-from": "^7.0.0"
@@ -383,10 +375,9 @@
         },
         "@babel/plugin-proposal-nullish-coalescing-operator": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.0.0.tgz",
-            "integrity":
-                "sha512-QIN3UFo1ul4ruAsjIqK43PeXedo1qY74zeGrODJl1KfCGeMc6qJC4rb5Ylml/smzxibqsDeVZGH+TmWHCldRQQ==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.0.0.tgz",
+            "integrity": "sha512-QIN3UFo1ul4ruAsjIqK43PeXedo1qY74zeGrODJl1KfCGeMc6qJC4rb5Ylml/smzxibqsDeVZGH+TmWHCldRQQ==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0"
@@ -394,10 +385,9 @@
         },
         "@babel/plugin-proposal-object-rest-spread": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
-            "integrity":
-                "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
+            "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
@@ -405,10 +395,9 @@
         },
         "@babel/plugin-proposal-optional-catch-binding": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0.tgz",
-            "integrity":
-                "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0.tgz",
+            "integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
@@ -416,10 +405,9 @@
         },
         "@babel/plugin-proposal-optional-chaining": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.0.0.tgz",
-            "integrity":
-                "sha512-7x8HLa71OzNiofbQUVakS0Kmg++6a+cXNfS7QKHbbv03SuSaumJyaWsfNgw+T7aqrJlqurYpZqrkPgXu0iZK0w==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.0.0.tgz",
+            "integrity": "sha512-7x8HLa71OzNiofbQUVakS0Kmg++6a+cXNfS7QKHbbv03SuSaumJyaWsfNgw+T7aqrJlqurYpZqrkPgXu0iZK0w==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/plugin-syntax-optional-chaining": "^7.0.0"
@@ -427,30 +415,27 @@
         },
         "@babel/plugin-syntax-class-properties": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz",
-            "integrity":
-                "sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz",
+            "integrity": "sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-syntax-dynamic-import": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz",
-            "integrity":
-                "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz",
+            "integrity": "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-syntax-export-default-from": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.0.0.tgz",
-            "integrity":
-                "sha512-HNnjg/fFFbnuLAqr/Ocp1Y3GB4AjmXcu1xxn3ql3bS2kGrB/qi+Povshb8i3hOkE5jNozzh8r/0/lq1w8oOWbQ==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.0.0.tgz",
+            "integrity": "sha512-HNnjg/fFFbnuLAqr/Ocp1Y3GB4AjmXcu1xxn3ql3bS2kGrB/qi+Povshb8i3hOkE5jNozzh8r/0/lq1w8oOWbQ==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
@@ -458,8 +443,8 @@
         "@babel/plugin-syntax-flow": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0.tgz",
-            "integrity":
-                "sha512-zGcuZWiWWDa5qTZ6iAnpG0fnX/GOu49pGR5PFvkQ9GmKNaSphXQnlNXh/LG20sqWtNrx/eB6krzfEzcwvUyeFA==",
+            "integrity": "sha512-zGcuZWiWWDa5qTZ6iAnpG0fnX/GOu49pGR5PFvkQ9GmKNaSphXQnlNXh/LG20sqWtNrx/eB6krzfEzcwvUyeFA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
@@ -467,78 +452,71 @@
         "@babel/plugin-syntax-jsx": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0.tgz",
-            "integrity":
-                "sha512-PdmL2AoPsCLWxhIr3kG2+F9v4WH06Q3z+NoGVpQgnUNGcagXHq5sB3OXxkSahKq9TLdNMN/AJzFYSOo8UKDMHg==",
+            "integrity": "sha512-PdmL2AoPsCLWxhIr3kG2+F9v4WH06Q3z+NoGVpQgnUNGcagXHq5sB3OXxkSahKq9TLdNMN/AJzFYSOo8UKDMHg==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-syntax-nullish-coalescing-operator": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.0.0.tgz",
-            "integrity":
-                "sha512-oAJmMsAvTSIk9y0sZdU2S/nY44PEUuHN7EzNDMgbuR4e/OwyfR9lSmoBJBZ2lslFZIqhksrTt4i+av7uKfNYDw==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.0.0.tgz",
+            "integrity": "sha512-oAJmMsAvTSIk9y0sZdU2S/nY44PEUuHN7EzNDMgbuR4e/OwyfR9lSmoBJBZ2lslFZIqhksrTt4i+av7uKfNYDw==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-syntax-object-rest-spread": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",
-            "integrity":
-                "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",
+            "integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-syntax-optional-catch-binding": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz",
-            "integrity":
-                "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz",
+            "integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-syntax-optional-chaining": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.0.0.tgz",
-            "integrity":
-                "sha512-QXedQsZf8yua1nNrXSePT0TsGSQH9A1iK08m9dhCMdZeJaaxYcQfXdgHWVV6Cp7WE/afPVvSKIsAHK5wP+yxDA==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.0.0.tgz",
+            "integrity": "sha512-QXedQsZf8yua1nNrXSePT0TsGSQH9A1iK08m9dhCMdZeJaaxYcQfXdgHWVV6Cp7WE/afPVvSKIsAHK5wP+yxDA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-syntax-typescript": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.0.0.tgz",
-            "integrity":
-                "sha512-5fxmdqiAQVQTIS+KSvYeZuTt91wKtBTYi6JlIkvbQ6hmO+9fZE81ezxmMiFMIsxE7CdRSgzn7nQ1BChcvK9OpA==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.0.0.tgz",
+            "integrity": "sha512-5fxmdqiAQVQTIS+KSvYeZuTt91wKtBTYi6JlIkvbQ6hmO+9fZE81ezxmMiFMIsxE7CdRSgzn7nQ1BChcvK9OpA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-arrow-functions": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz",
-            "integrity":
-                "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz",
+            "integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-async-to-generator": {
             "version": "7.1.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.1.0.tgz",
-            "integrity":
-                "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.1.0.tgz",
+            "integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
+            "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.0.0",
                 "@babel/helper-plugin-utils": "^7.0.0",
@@ -547,10 +525,9 @@
         },
         "@babel/plugin-transform-block-scoping": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
-            "integrity":
-                "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
+            "integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "lodash": "^4.17.10"
@@ -558,10 +535,9 @@
         },
         "@babel/plugin-transform-classes": {
             "version": "7.1.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
-            "integrity":
-                "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
+            "integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
+            "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.0.0",
                 "@babel/helper-define-map": "^7.1.0",
@@ -576,37 +552,34 @@
                 "globals": {
                     "version": "11.8.0",
                     "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-                    "integrity":
-                        "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA=="
+                    "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+                    "dev": true
                 }
             }
         },
         "@babel/plugin-transform-computed-properties": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz",
-            "integrity":
-                "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz",
+            "integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-destructuring": {
             "version": "7.1.2",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.1.2.tgz",
-            "integrity":
-                "sha512-cvToXvp/OsYxtEn57XJu9BvsGSEYjAh9UeUuXpoi7x6QHB7YdWyQ4lRU/q0Fu1IJNT0o0u4FQ1DMQBzJ8/8vZg==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.1.2.tgz",
+            "integrity": "sha512-cvToXvp/OsYxtEn57XJu9BvsGSEYjAh9UeUuXpoi7x6QHB7YdWyQ4lRU/q0Fu1IJNT0o0u4FQ1DMQBzJ8/8vZg==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-exponentiation-operator": {
             "version": "7.1.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.1.0.tgz",
-            "integrity":
-                "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.1.0.tgz",
+            "integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
+            "dev": true,
             "requires": {
                 "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
                 "@babel/helper-plugin-utils": "^7.0.0"
@@ -614,10 +587,9 @@
         },
         "@babel/plugin-transform-flow-strip-types": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0.tgz",
-            "integrity":
-                "sha512-WhXUNb4It5a19RsgKKbQPrjmy4yWOY1KynpEbNw7bnd1QTcrT/EIl3MJvnGgpgvrKyKbqX7nUNOJfkpLOnoDKA==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0.tgz",
+            "integrity": "sha512-WhXUNb4It5a19RsgKKbQPrjmy4yWOY1KynpEbNw7bnd1QTcrT/EIl3MJvnGgpgvrKyKbqX7nUNOJfkpLOnoDKA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/plugin-syntax-flow": "^7.0.0"
@@ -626,18 +598,17 @@
         "@babel/plugin-transform-for-of": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0.tgz",
-            "integrity":
-                "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
+            "integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-function-name": {
             "version": "7.1.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.1.0.tgz",
-            "integrity":
-                "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.1.0.tgz",
+            "integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
+            "dev": true,
             "requires": {
                 "@babel/helper-function-name": "^7.1.0",
                 "@babel/helper-plugin-utils": "^7.0.0"
@@ -645,20 +616,18 @@
         },
         "@babel/plugin-transform-literals": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
-            "integrity":
-                "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
+            "integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-modules-commonjs": {
             "version": "7.1.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
-            "integrity":
-                "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
+            "integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-module-transforms": "^7.1.0",
                 "@babel/helper-plugin-utils": "^7.0.0",
@@ -667,20 +636,18 @@
         },
         "@babel/plugin-transform-object-assign": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.0.0.tgz",
-            "integrity":
-                "sha512-Dag8mxx7/03oj8F8PkNso8GEMhwGfeT0TL6KfMsa9Brjx4IpwZVl3WBvEmYks8BMhPmrvM5NQ/tjaMbwEj5ijA==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.0.0.tgz",
+            "integrity": "sha512-Dag8mxx7/03oj8F8PkNso8GEMhwGfeT0TL6KfMsa9Brjx4IpwZVl3WBvEmYks8BMhPmrvM5NQ/tjaMbwEj5ijA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-parameters": {
             "version": "7.1.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.1.0.tgz",
-            "integrity":
-                "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.1.0.tgz",
+            "integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
+            "dev": true,
             "requires": {
                 "@babel/helper-call-delegate": "^7.1.0",
                 "@babel/helper-get-function-arity": "^7.0.0",
@@ -689,20 +656,18 @@
         },
         "@babel/plugin-transform-react-display-name": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0.tgz",
-            "integrity":
-                "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0.tgz",
+            "integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-react-jsx": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0.tgz",
-            "integrity":
-                "sha512-0TMP21hXsSUjIQJmu/r7RiVxeFrXRcMUigbKu0BLegJK9PkYodHstaszcig7zxXfaBji2LYUdtqIkHs+hgYkJQ==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0.tgz",
+            "integrity": "sha512-0TMP21hXsSUjIQJmu/r7RiVxeFrXRcMUigbKu0BLegJK9PkYodHstaszcig7zxXfaBji2LYUdtqIkHs+hgYkJQ==",
+            "dev": true,
             "requires": {
                 "@babel/helper-builder-react-jsx": "^7.0.0",
                 "@babel/helper-plugin-utils": "^7.0.0",
@@ -711,10 +676,9 @@
         },
         "@babel/plugin-transform-react-jsx-source": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0.tgz",
-            "integrity":
-                "sha512-OSeEpFJEH5dw/TtxTg4nijl4nHBbhqbKL94Xo/Y17WKIf2qJWeIk/QeXACF19lG1vMezkxqruwnTjVizaW7u7w==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0.tgz",
+            "integrity": "sha512-OSeEpFJEH5dw/TtxTg4nijl4nHBbhqbKL94Xo/Y17WKIf2qJWeIk/QeXACF19lG1vMezkxqruwnTjVizaW7u7w==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/plugin-syntax-jsx": "^7.0.0"
@@ -722,10 +686,9 @@
         },
         "@babel/plugin-transform-regenerator": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
-            "integrity":
-                "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
+            "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+            "dev": true,
             "requires": {
                 "regenerator-transform": "^0.13.3"
             },
@@ -733,8 +696,8 @@
                 "regenerator-transform": {
                     "version": "0.13.3",
                     "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
-                    "integrity":
-                        "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+                    "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+                    "dev": true,
                     "requires": {
                         "private": "^0.1.6"
                     }
@@ -743,10 +706,9 @@
         },
         "@babel/plugin-transform-shorthand-properties": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
-            "integrity":
-                "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
+            "integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
@@ -754,18 +716,17 @@
         "@babel/plugin-transform-spread": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0.tgz",
-            "integrity":
-                "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
+            "integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-sticky-regex": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz",
-            "integrity":
-                "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz",
+            "integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/helper-regex": "^7.0.0"
@@ -773,10 +734,9 @@
         },
         "@babel/plugin-transform-template-literals": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz",
-            "integrity":
-                "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz",
+            "integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
+            "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.0.0",
                 "@babel/helper-plugin-utils": "^7.0.0"
@@ -784,10 +744,9 @@
         },
         "@babel/plugin-transform-typescript": {
             "version": "7.1.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.1.0.tgz",
-            "integrity":
-                "sha512-TOTtVeT+fekAesiCHnPz+PSkYSdOSLyLn42DI45nxg6iCdlQY6LIj/tYqpMB0y+YicoTUiYiXqF8rG6SKfhw6Q==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.1.0.tgz",
+            "integrity": "sha512-TOTtVeT+fekAesiCHnPz+PSkYSdOSLyLn42DI45nxg6iCdlQY6LIj/tYqpMB0y+YicoTUiYiXqF8rG6SKfhw6Q==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/plugin-syntax-typescript": "^7.0.0"
@@ -795,10 +754,9 @@
         },
         "@babel/plugin-transform-unicode-regex": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
-            "integrity":
-                "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
+            "integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/helper-regex": "^7.0.0",
@@ -808,8 +766,8 @@
         "@babel/register": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0.tgz",
-            "integrity":
-                "sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==",
+            "integrity": "sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==",
+            "dev": true,
             "requires": {
                 "core-js": "^2.5.7",
                 "find-cache-dir": "^1.0.0",
@@ -823,19 +781,20 @@
                 "home-or-tmp": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
-                    "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs="
+                    "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=",
+                    "dev": true
                 },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity":
-                        "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
                 },
                 "source-map-support": {
                     "version": "0.5.9",
                     "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-                    "integrity":
-                        "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+                    "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+                    "dev": true,
                     "requires": {
                         "buffer-from": "^1.0.0",
                         "source-map": "^0.6.0"
@@ -846,8 +805,8 @@
         "@babel/template": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
-            "integrity":
-                "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+            "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
                 "@babel/parser": "^7.1.2",
@@ -857,8 +816,8 @@
         "@babel/traverse": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.0.tgz",
-            "integrity":
-                "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
+            "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
                 "@babel/generator": "^7.0.0",
@@ -874,8 +833,8 @@
                 "debug": {
                     "version": "3.2.5",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-                    "integrity":
-                        "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
                     }
@@ -883,22 +842,22 @@
                 "globals": {
                     "version": "11.8.0",
                     "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-                    "integrity":
-                        "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA=="
+                    "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+                    "dev": true
                 },
                 "ms": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity":
-                        "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
                 }
             }
         },
         "@babel/types": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.2.tgz",
-            "integrity":
-                "sha512-pb1I05sZEKiSlMUV9UReaqsCPUpgbHHHu2n1piRm7JkuBkm6QxcaIzKu6FMnMtCbih/cEYTR+RGYYC96Yk9HAg==",
+            "integrity": "sha512-pb1I05sZEKiSlMUV9UReaqsCPUpgbHHHu2n1piRm7JkuBkm6QxcaIzKu6FMnMtCbih/cEYTR+RGYYC96Yk9HAg==",
+            "dev": true,
             "requires": {
                 "esutils": "^2.0.2",
                 "lodash": "^4.17.10",
@@ -908,21 +867,22 @@
                 "to-fast-properties": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
                 }
             }
         },
         "@types/prop-types": {
             "version": "15.5.6",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.6.tgz",
-            "integrity":
-                "sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ=="
+            "integrity": "sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ==",
+            "dev": true
         },
         "@types/react": {
             "version": "16.4.14",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.14.tgz",
-            "integrity":
-                "sha512-Gh8irag2dbZ2K6vPn+S8+LNrULuG3zlCgJjVUrvuiUK7waw9d9CFk2A/tZFyGhcMDUyO7tznbx1ZasqlAGjHxA==",
+            "integrity": "sha512-Gh8irag2dbZ2K6vPn+S8+LNrULuG3zlCgJjVUrvuiUK7waw9d9CFk2A/tZFyGhcMDUyO7tznbx1ZasqlAGjHxA==",
+            "dev": true,
             "requires": {
                 "@types/prop-types": "*",
                 "csstype": "^2.2.0"
@@ -931,8 +891,8 @@
         "@types/react-native": {
             "version": "0.57.0",
             "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.57.0.tgz",
-            "integrity":
-                "sha512-eJPaY7SIx9R7UlYxmV/h/8gJHfgIYDu0nqmZy9FlY8sB8zOA7moa15FsouFe46illwOBLeT8S0iAwrOirp9mbA==",
+            "integrity": "sha512-eJPaY7SIx9R7UlYxmV/h/8gJHfgIYDu0nqmZy9FlY8sB8zOA7moa15FsouFe46illwOBLeT8S0iAwrOirp9mbA==",
+            "dev": true,
             "requires": {
                 "@types/prop-types": "*",
                 "@types/react": "*"
@@ -941,12 +901,14 @@
         "absolute-path": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/absolute-path/-/absolute-path-0.0.0.tgz",
-            "integrity": "sha1-p4di+9rftSl76ZsV01p4Wy8JW/c="
+            "integrity": "sha1-p4di+9rftSl76ZsV01p4Wy8JW/c=",
+            "dev": true
         },
         "accepts": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
             "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+            "dev": true,
             "requires": {
                 "mime-types": "~2.1.18",
                 "negotiator": "0.6.1"
@@ -955,13 +917,14 @@
         "ansi": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-            "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
+            "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
+            "dev": true
         },
         "ansi-colors": {
             "version": "1.1.0",
             "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
-            "integrity":
-                "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+            "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+            "dev": true,
             "requires": {
                 "ansi-wrap": "^0.1.0"
             }
@@ -970,6 +933,7 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
             "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+            "dev": true,
             "requires": {
                 "ansi-wrap": "0.1.0"
             }
@@ -977,13 +941,14 @@
         "ansi-escapes": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-            "integrity":
-                "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+            "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+            "dev": true
         },
         "ansi-gray": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
             "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+            "dev": true,
             "requires": {
                 "ansi-wrap": "0.1.0"
             }
@@ -992,6 +957,7 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
             "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+            "dev": true,
             "requires": {
                 "ansi-wrap": "0.1.0"
             }
@@ -999,23 +965,26 @@
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
         },
         "ansi-styles": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
         },
         "ansi-wrap": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+            "dev": true
         },
         "anymatch": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-            "integrity":
-                "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+            "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+            "dev": true,
             "requires": {
                 "micromatch": "^3.1.4",
                 "normalize-path": "^2.1.1"
@@ -1024,18 +993,20 @@
                 "arr-diff": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
                 },
                 "array-unique": {
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
                 },
                 "braces": {
                     "version": "2.3.2",
                     "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity":
-                        "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
                     "requires": {
                         "arr-flatten": "^1.1.0",
                         "array-unique": "^0.3.2",
@@ -1053,6 +1024,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -1063,6 +1035,7 @@
                     "version": "2.1.4",
                     "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
                     "requires": {
                         "debug": "^2.3.3",
                         "define-property": "^0.2.5",
@@ -1077,6 +1050,7 @@
                             "version": "0.2.5",
                             "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
                             "requires": {
                                 "is-descriptor": "^0.1.0"
                             }
@@ -1085,15 +1059,16 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
                             "version": "0.1.6",
-                            "resolved":
-                                "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
                             "requires": {
                                 "kind-of": "^3.0.2"
                             },
@@ -1102,6 +1077,7 @@
                                     "version": "3.2.2",
                                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
                                     "requires": {
                                         "is-buffer": "^1.1.5"
                                     }
@@ -1112,6 +1088,7 @@
                             "version": "0.1.4",
                             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
                             "requires": {
                                 "kind-of": "^3.0.2"
                             },
@@ -1120,6 +1097,7 @@
                                     "version": "3.2.2",
                                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
                                     "requires": {
                                         "is-buffer": "^1.1.5"
                                     }
@@ -1129,8 +1107,8 @@
                         "is-descriptor": {
                             "version": "0.1.6",
                             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                            "integrity":
-                                "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
                             "requires": {
                                 "is-accessor-descriptor": "^0.1.6",
                                 "is-data-descriptor": "^0.1.4",
@@ -1140,8 +1118,8 @@
                         "kind-of": {
                             "version": "5.1.0",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                            "integrity":
-                                "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
                         }
                     }
                 },
@@ -1149,6 +1127,7 @@
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
                     "requires": {
                         "assign-symbols": "^1.0.0",
                         "is-extendable": "^1.0.1"
@@ -1157,8 +1136,8 @@
                         "is-extendable": {
                             "version": "1.0.1",
                             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                            "integrity":
-                                "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                            "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                            "dev": true,
                             "requires": {
                                 "is-plain-object": "^2.0.4"
                             }
@@ -1168,8 +1147,8 @@
                 "extglob": {
                     "version": "2.0.4",
                     "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-                    "integrity":
-                        "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
                     "requires": {
                         "array-unique": "^0.3.2",
                         "define-property": "^1.0.0",
@@ -1185,6 +1164,7 @@
                             "version": "1.0.0",
                             "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
                             "requires": {
                                 "is-descriptor": "^1.0.0"
                             }
@@ -1193,6 +1173,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -1203,6 +1184,7 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
                     "requires": {
                         "extend-shallow": "^2.0.1",
                         "is-number": "^3.0.0",
@@ -1214,6 +1196,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -1223,8 +1206,8 @@
                 "is-accessor-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1232,8 +1215,8 @@
                 "is-data-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1241,8 +1224,8 @@
                 "is-descriptor": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity":
-                        "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -1253,6 +1236,7 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^3.0.2"
                     },
@@ -1261,6 +1245,7 @@
                             "version": "3.2.2",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
                             "requires": {
                                 "is-buffer": "^1.1.5"
                             }
@@ -1270,19 +1255,20 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 },
                 "kind-of": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity":
-                        "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
                 },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-                    "integrity":
-                        "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
                     "requires": {
                         "arr-diff": "^4.0.0",
                         "array-unique": "^0.3.2",
@@ -1304,8 +1290,8 @@
         "are-we-there-yet": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-            "integrity":
-                "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+            "dev": true,
             "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -1314,8 +1300,8 @@
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity":
-                "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
             }
@@ -1324,6 +1310,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
             "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+            "dev": true,
             "requires": {
                 "arr-flatten": "^1.0.1",
                 "array-slice": "^0.2.3"
@@ -1332,60 +1319,68 @@
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity":
-                "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "dev": true
         },
         "arr-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
-            "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0="
+            "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+            "dev": true
         },
         "array-filter": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-            "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+            "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+            "dev": true
         },
         "array-map": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-            "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+            "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+            "dev": true
         },
         "array-reduce": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-            "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+            "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+            "dev": true
         },
         "array-slice": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-            "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
+            "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+            "dev": true
         },
         "array-unique": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "dev": true
         },
         "art": {
             "version": "0.10.3",
             "resolved": "https://registry.npmjs.org/art/-/art-0.10.3.tgz",
-            "integrity":
-                "sha512-HXwbdofRTiJT6qZX/FnchtldzJjS3vkLJxQilc3Xj+ma2MXjY4UAyQ0ls1XZYVnDvVIBiFZbC6QsvtW86TD6tQ=="
+            "integrity": "sha512-HXwbdofRTiJT6qZX/FnchtldzJjS3vkLJxQilc3Xj+ma2MXjY4UAyQ0ls1XZYVnDvVIBiFZbC6QsvtW86TD6tQ==",
+            "dev": true
         },
         "asap": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+            "dev": true
         },
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+            "dev": true
         },
         "async": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-            "integrity":
-                "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+            "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+            "dev": true,
             "requires": {
                 "lodash": "^4.17.10"
             }
@@ -1393,19 +1388,20 @@
         "async-limiter": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-            "integrity":
-                "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+            "dev": true
         },
         "atob": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity":
-                "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "dev": true
         },
         "babel-code-frame": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true,
             "requires": {
                 "chalk": "^1.1.3",
                 "esutils": "^2.0.2",
@@ -1415,8 +1411,8 @@
         "babel-core": {
             "version": "6.26.3",
             "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-            "integrity":
-                "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+            "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+            "dev": true,
             "requires": {
                 "babel-code-frame": "^6.26.0",
                 "babel-generator": "^6.26.0",
@@ -1442,8 +1438,8 @@
         "babel-generator": {
             "version": "6.26.1",
             "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-            "integrity":
-                "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+            "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+            "dev": true,
             "requires": {
                 "babel-messages": "^6.23.0",
                 "babel-runtime": "^6.26.0",
@@ -1457,9 +1453,9 @@
         },
         "babel-helper-builder-binary-assignment-operator-visitor": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
             "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+            "dev": true,
             "requires": {
                 "babel-helper-explode-assignable-expression": "^6.24.1",
                 "babel-runtime": "^6.22.0",
@@ -1468,9 +1464,9 @@
         },
         "babel-helper-builder-react-jsx": {
             "version": "6.26.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
             "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.26.0",
                 "babel-types": "^6.26.0",
@@ -1481,6 +1477,7 @@
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
             "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+            "dev": true,
             "requires": {
                 "babel-helper-hoist-variables": "^6.24.1",
                 "babel-runtime": "^6.22.0",
@@ -1492,6 +1489,7 @@
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
             "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+            "dev": true,
             "requires": {
                 "babel-helper-function-name": "^6.24.1",
                 "babel-runtime": "^6.26.0",
@@ -1501,9 +1499,9 @@
         },
         "babel-helper-explode-assignable-expression": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
             "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0",
                 "babel-traverse": "^6.24.1",
@@ -1514,6 +1512,7 @@
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
             "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+            "dev": true,
             "requires": {
                 "babel-helper-get-function-arity": "^6.24.1",
                 "babel-runtime": "^6.22.0",
@@ -1524,9 +1523,9 @@
         },
         "babel-helper-get-function-arity": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
             "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0",
                 "babel-types": "^6.24.1"
@@ -1534,9 +1533,9 @@
         },
         "babel-helper-hoist-variables": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
             "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0",
                 "babel-types": "^6.24.1"
@@ -1544,9 +1543,9 @@
         },
         "babel-helper-optimise-call-expression": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
             "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0",
                 "babel-types": "^6.24.1"
@@ -1554,9 +1553,9 @@
         },
         "babel-helper-replace-supers": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
             "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+            "dev": true,
             "requires": {
                 "babel-helper-optimise-call-expression": "^6.24.1",
                 "babel-messages": "^6.23.0",
@@ -1570,6 +1569,7 @@
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
             "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0",
                 "babel-template": "^6.24.1"
@@ -1579,80 +1579,82 @@
             "version": "6.23.0",
             "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-check-es2015-constants": {
             "version": "6.22.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
             "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-react-transform": {
             "version": "3.0.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-3.0.0.tgz",
-            "integrity":
-                "sha512-4vJGddwPiHAOgshzZdGwYy4zRjjIr5SMY7gkOaCyIASjgpcsyLTlZNuB5rHOFoaTvGlhfo8/g4pobXPyHqm/3w==",
+            "resolved": "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-3.0.0.tgz",
+            "integrity": "sha512-4vJGddwPiHAOgshzZdGwYy4zRjjIr5SMY7gkOaCyIASjgpcsyLTlZNuB5rHOFoaTvGlhfo8/g4pobXPyHqm/3w==",
+            "dev": true,
             "requires": {
                 "lodash": "^4.6.1"
             }
         },
         "babel-plugin-syntax-async-functions": {
             "version": "6.13.0",
-            "resolved":
-                "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-            "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+            "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+            "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+            "dev": true
         },
         "babel-plugin-syntax-class-properties": {
             "version": "6.13.0",
-            "resolved":
-                "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-            "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
+            "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+            "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+            "dev": true
         },
         "babel-plugin-syntax-dynamic-import": {
             "version": "6.18.0",
-            "resolved":
-                "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-            "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
+            "resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+            "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+            "dev": true
         },
         "babel-plugin-syntax-exponentiation-operator": {
             "version": "6.13.0",
-            "resolved":
-                "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-            "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+            "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+            "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+            "dev": true
         },
         "babel-plugin-syntax-flow": {
             "version": "6.18.0",
             "resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-            "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+            "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+            "dev": true
         },
         "babel-plugin-syntax-jsx": {
             "version": "6.18.0",
             "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-            "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+            "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+            "dev": true
         },
         "babel-plugin-syntax-object-rest-spread": {
             "version": "6.13.0",
-            "resolved":
-                "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-            "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+            "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+            "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+            "dev": true
         },
         "babel-plugin-syntax-trailing-function-commas": {
             "version": "6.22.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-            "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+            "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+            "dev": true
         },
         "babel-plugin-transform-class-properties": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
             "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+            "dev": true,
             "requires": {
                 "babel-helper-function-name": "^6.24.1",
                 "babel-plugin-syntax-class-properties": "^6.8.0",
@@ -1662,27 +1664,27 @@
         },
         "babel-plugin-transform-es2015-arrow-functions": {
             "version": "6.22.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
             "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
             "version": "6.22.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
             "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoping": {
             "version": "6.26.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
             "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.26.0",
                 "babel-template": "^6.26.0",
@@ -1693,9 +1695,9 @@
         },
         "babel-plugin-transform-es2015-classes": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
             "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+            "dev": true,
             "requires": {
                 "babel-helper-define-map": "^6.24.1",
                 "babel-helper-function-name": "^6.24.1",
@@ -1710,9 +1712,9 @@
         },
         "babel-plugin-transform-es2015-computed-properties": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
             "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0",
                 "babel-template": "^6.24.1"
@@ -1720,27 +1722,27 @@
         },
         "babel-plugin-transform-es2015-destructuring": {
             "version": "6.23.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
             "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-for-of": {
             "version": "6.23.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
             "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-function-name": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
             "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+            "dev": true,
             "requires": {
                 "babel-helper-function-name": "^6.24.1",
                 "babel-runtime": "^6.22.0",
@@ -1749,19 +1751,18 @@
         },
         "babel-plugin-transform-es2015-literals": {
             "version": "6.22.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
             "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
             "version": "6.26.2",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-            "integrity":
-                "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+            "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+            "dev": true,
             "requires": {
                 "babel-plugin-transform-strict-mode": "^6.24.1",
                 "babel-runtime": "^6.26.0",
@@ -1771,9 +1772,9 @@
         },
         "babel-plugin-transform-es2015-object-super": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
             "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+            "dev": true,
             "requires": {
                 "babel-helper-replace-supers": "^6.24.1",
                 "babel-runtime": "^6.22.0"
@@ -1781,9 +1782,9 @@
         },
         "babel-plugin-transform-es2015-parameters": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
             "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+            "dev": true,
             "requires": {
                 "babel-helper-call-delegate": "^6.24.1",
                 "babel-helper-get-function-arity": "^6.24.1",
@@ -1795,9 +1796,9 @@
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
             "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0",
                 "babel-types": "^6.24.1"
@@ -1805,45 +1806,45 @@
         },
         "babel-plugin-transform-es2015-spread": {
             "version": "6.22.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
             "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-template-literals": {
             "version": "6.22.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
             "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es3-member-expression-literals": {
             "version": "6.22.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.22.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.22.0.tgz",
             "integrity": "sha1-cz00RPPsxBvvjtGmpOCWV7iWnrs=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es3-property-literals": {
             "version": "6.22.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
             "integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-exponentiation-operator": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
             "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+            "dev": true,
             "requires": {
                 "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
                 "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
@@ -1852,9 +1853,9 @@
         },
         "babel-plugin-transform-flow-strip-types": {
             "version": "6.22.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
             "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+            "dev": true,
             "requires": {
                 "babel-plugin-syntax-flow": "^6.18.0",
                 "babel-runtime": "^6.22.0"
@@ -1862,18 +1863,18 @@
         },
         "babel-plugin-transform-object-assign": {
             "version": "6.22.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz",
             "integrity": "sha1-+Z0vZvGgsNSY40bFNZaEdAyqILo=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-object-rest-spread": {
             "version": "6.26.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
             "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+            "dev": true,
             "requires": {
                 "babel-plugin-syntax-object-rest-spread": "^6.8.0",
                 "babel-runtime": "^6.26.0"
@@ -1881,18 +1882,18 @@
         },
         "babel-plugin-transform-react-display-name": {
             "version": "6.25.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
             "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-react-jsx": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
             "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+            "dev": true,
             "requires": {
                 "babel-helper-builder-react-jsx": "^6.24.1",
                 "babel-plugin-syntax-jsx": "^6.8.0",
@@ -1901,9 +1902,9 @@
         },
         "babel-plugin-transform-react-jsx-source": {
             "version": "6.22.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
             "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+            "dev": true,
             "requires": {
                 "babel-plugin-syntax-jsx": "^6.8.0",
                 "babel-runtime": "^6.22.0"
@@ -1911,18 +1912,18 @@
         },
         "babel-plugin-transform-regenerator": {
             "version": "6.26.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
             "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+            "dev": true,
             "requires": {
                 "regenerator-transform": "^0.10.0"
             }
         },
         "babel-plugin-transform-strict-mode": {
             "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
             "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0",
                 "babel-types": "^6.24.1"
@@ -1931,8 +1932,8 @@
         "babel-preset-fbjs": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.3.0.tgz",
-            "integrity":
-                "sha512-ZOpAI1/bN0Y3J1ZAK9gRsFkHy9gGgJoDRUjtUCla/129LC7uViq9nIK22YdHfey8szohYoZY3f9L2lGOv0Edqw==",
+            "integrity": "sha512-ZOpAI1/bN0Y3J1ZAK9gRsFkHy9gGgJoDRUjtUCla/129LC7uViq9nIK22YdHfey8szohYoZY3f9L2lGOv0Edqw==",
+            "dev": true,
             "requires": {
                 "babel-plugin-check-es2015-constants": "^6.8.0",
                 "babel-plugin-syntax-class-properties": "^6.8.0",
@@ -1967,8 +1968,8 @@
         "babel-preset-react-native": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-4.0.1.tgz",
-            "integrity":
-                "sha512-uhFXnl1WbEWNG4W8QB/jeQaVXkd0a0AD+wh4D2VqtdRnEyvscahqyHExnwKLU9N0sXRYwDyed4JfbiBtiOSGgA==",
+            "integrity": "sha512-uhFXnl1WbEWNG4W8QB/jeQaVXkd0a0AD+wh4D2VqtdRnEyvscahqyHExnwKLU9N0sXRYwDyed4JfbiBtiOSGgA==",
+            "dev": true,
             "requires": {
                 "babel-plugin-check-es2015-constants": "^6.5.0",
                 "babel-plugin-react-transform": "^3.0.0",
@@ -2008,6 +2009,7 @@
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
             "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+            "dev": true,
             "requires": {
                 "babel-core": "^6.26.0",
                 "babel-runtime": "^6.26.0",
@@ -2022,6 +2024,7 @@
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "dev": true,
             "requires": {
                 "core-js": "^2.4.0",
                 "regenerator-runtime": "^0.11.0"
@@ -2031,6 +2034,7 @@
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
             "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.26.0",
                 "babel-traverse": "^6.26.0",
@@ -2043,6 +2047,7 @@
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
             "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+            "dev": true,
             "requires": {
                 "babel-code-frame": "^6.26.0",
                 "babel-messages": "^6.23.0",
@@ -2059,6 +2064,7 @@
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.26.0",
                 "esutils": "^2.0.2",
@@ -2069,19 +2075,20 @@
         "babylon": {
             "version": "6.18.0",
             "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-            "integrity":
-                "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+            "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+            "dev": true
         },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
         },
         "base": {
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-            "integrity":
-                "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "dev": true,
             "requires": {
                 "cache-base": "^1.0.1",
                 "class-utils": "^0.3.5",
@@ -2096,6 +2103,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -2103,8 +2111,8 @@
                 "is-accessor-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -2112,8 +2120,8 @@
                 "is-data-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -2121,8 +2129,8 @@
                 "is-descriptor": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity":
-                        "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -2132,27 +2140,28 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 },
                 "kind-of": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity":
-                        "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
                 }
             }
         },
         "base64-js": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-            "integrity":
-                "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+            "dev": true
         },
         "basic-auth": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-            "integrity":
-                "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+            "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+            "dev": true,
             "requires": {
                 "safe-buffer": "5.1.2"
             }
@@ -2160,13 +2169,14 @@
         "big-integer": {
             "version": "1.6.36",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
-            "integrity":
-                "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
+            "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
+            "dev": true
         },
         "bplist-creator": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
             "integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
+            "dev": true,
             "requires": {
                 "stream-buffers": "~2.2.0"
             }
@@ -2175,6 +2185,7 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
             "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+            "dev": true,
             "requires": {
                 "big-integer": "^1.6.7"
             }
@@ -2182,8 +2193,8 @@
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity":
-                "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2193,6 +2204,7 @@
             "version": "1.8.5",
             "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "dev": true,
             "requires": {
                 "expand-range": "^1.8.1",
                 "preserve": "^0.2.0",
@@ -2203,6 +2215,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
             "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+            "dev": true,
             "requires": {
                 "node-int64": "^0.4.0"
             }
@@ -2210,24 +2223,26 @@
         "buffer-from": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-            "integrity":
-                "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
         },
         "builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
         },
         "bytes": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-            "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+            "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+            "dev": true
         },
         "cache-base": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-            "integrity":
-                "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "dev": true,
             "requires": {
                 "collection-visit": "^1.0.0",
                 "component-emitter": "^1.2.1",
@@ -2243,19 +2258,22 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
             }
         },
         "camelcase": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-            "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+            "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+            "dev": true
         },
         "capture-exit": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
             "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+            "dev": true,
             "requires": {
                 "rsvp": "^3.3.3"
             }
@@ -2264,6 +2282,7 @@
             "version": "1.1.3",
             "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
             "requires": {
                 "ansi-styles": "^2.2.1",
                 "escape-string-regexp": "^1.0.2",
@@ -2275,13 +2294,14 @@
         "chardet": {
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-            "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+            "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+            "dev": true
         },
         "class-utils": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-            "integrity":
-                "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "define-property": "^0.2.5",
@@ -2292,12 +2312,14 @@
                 "arr-union": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-                    "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+                    "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+                    "dev": true
                 },
                 "define-property": {
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -2305,7 +2327,8 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
             }
         },
@@ -2313,6 +2336,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "dev": true,
             "requires": {
                 "restore-cursor": "^2.0.0"
             }
@@ -2320,12 +2344,14 @@
         "cli-width": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+            "dev": true
         },
         "cliui": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+            "dev": true,
             "requires": {
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1",
@@ -2334,9 +2360,9 @@
             "dependencies": {
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2345,6 +2371,7 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2356,12 +2383,14 @@
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
         },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "dev": true,
             "requires": {
                 "map-visit": "^1.0.0",
                 "object-visit": "^1.0.0"
@@ -2370,8 +2399,8 @@
         "color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity":
-                "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -2379,35 +2408,38 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
         },
         "color-support": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity":
-                "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+            "dev": true
         },
         "commander": {
             "version": "2.18.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
-            "integrity":
-                "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ=="
+            "integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==",
+            "dev": true
         },
         "commondir": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+            "dev": true
         },
         "component-emitter": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+            "dev": true
         },
         "compressible": {
             "version": "2.0.15",
             "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
-            "integrity":
-                "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
+            "integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
+            "dev": true,
             "requires": {
                 "mime-db": ">= 1.36.0 < 2"
             }
@@ -2415,8 +2447,8 @@
         "compression": {
             "version": "1.7.3",
             "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
-            "integrity":
-                "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+            "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+            "dev": true,
             "requires": {
                 "accepts": "~1.3.5",
                 "bytes": "3.0.0",
@@ -2430,13 +2462,14 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "concat-stream": {
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity":
-                "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
                 "inherits": "^2.0.3",
@@ -2448,6 +2481,7 @@
             "version": "3.6.6",
             "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
             "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+            "dev": true,
             "requires": {
                 "debug": "2.6.9",
                 "finalhandler": "1.1.0",
@@ -2458,8 +2492,8 @@
         "convert-source-map": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-            "integrity":
-                "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+            "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+            "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.1"
             }
@@ -2467,24 +2501,26 @@
         "copy-descriptor": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+            "dev": true
         },
         "core-js": {
             "version": "2.5.7",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-            "integrity":
-                "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+            "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+            "dev": true
         },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
         },
         "cosmiconfig": {
             "version": "5.0.6",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
-            "integrity":
-                "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
+            "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
+            "dev": true,
             "requires": {
                 "is-directory": "^0.3.1",
                 "js-yaml": "^3.9.0",
@@ -2494,8 +2530,8 @@
         "create-react-class": {
             "version": "15.6.3",
             "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
-            "integrity":
-                "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+            "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+            "dev": true,
             "requires": {
                 "fbjs": "^0.8.9",
                 "loose-envify": "^1.3.1",
@@ -2506,6 +2542,7 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "dev": true,
             "requires": {
                 "lru-cache": "^4.0.1",
                 "shebang-command": "^1.2.0",
@@ -2515,14 +2552,14 @@
         "csstype": {
             "version": "2.5.7",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.7.tgz",
-            "integrity":
-                "sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw=="
+            "integrity": "sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw==",
+            "dev": true
         },
         "debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity":
-                "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
             "requires": {
                 "ms": "2.0.0"
             }
@@ -2530,18 +2567,20 @@
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
         },
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "dev": true
         },
         "define-property": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-            "integrity":
-                "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "dev": true,
             "requires": {
                 "is-descriptor": "^1.0.2",
                 "isobject": "^3.0.1"
@@ -2550,8 +2589,8 @@
                 "is-accessor-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -2559,8 +2598,8 @@
                 "is-data-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -2568,8 +2607,8 @@
                 "is-descriptor": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity":
-                        "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -2579,40 +2618,46 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 },
                 "kind-of": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity":
-                        "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
                 }
             }
         },
         "delegates": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+            "dev": true
         },
         "denodeify": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
-            "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE="
+            "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
+            "dev": true
         },
         "depd": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+            "dev": true
         },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+            "dev": true
         },
         "detect-indent": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
             "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+            "dev": true,
             "requires": {
                 "repeating": "^2.0.0"
             }
@@ -2620,27 +2665,32 @@
         "detect-newline": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-            "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+            "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+            "dev": true
         },
         "dom-walk": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-            "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+            "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+            "dev": true
         },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+            "dev": true
         },
         "encodeurl": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+            "dev": true
         },
         "encoding": {
             "version": "0.1.12",
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
             "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+            "dev": true,
             "requires": {
                 "iconv-lite": "~0.4.13"
             }
@@ -2648,14 +2698,14 @@
         "envinfo": {
             "version": "5.10.0",
             "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-5.10.0.tgz",
-            "integrity":
-                "sha512-rXbzXWvnQxy+TcqZlARbWVQwgGVVouVJgFZhLVN5htjLxl1thstrP2ZGi0pXC309AbK7gVOPU+ulz/tmpCI7iw=="
+            "integrity": "sha512-rXbzXWvnQxy+TcqZlARbWVQwgGVVouVJgFZhLVN5htjLxl1thstrP2ZGi0pXC309AbK7gVOPU+ulz/tmpCI7iw==",
+            "dev": true
         },
         "error-ex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-            "integrity":
-                "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
@@ -2664,6 +2714,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.0.tgz",
             "integrity": "sha1-6rpkyl1UKjEayUX1gt78M2Fl2fQ=",
+            "dev": true,
             "requires": {
                 "accepts": "~1.3.3",
                 "escape-html": "~1.0.3"
@@ -2672,45 +2723,50 @@
         "escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+            "dev": true
         },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
         },
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity":
-                "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
         },
         "esutils": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
         },
         "etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "dev": true
         },
         "event-target-shim": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-1.1.1.tgz",
-            "integrity": "sha1-qG5e5r2qFgVEddp5fM3fDFVphJE="
+            "integrity": "sha1-qG5e5r2qFgVEddp5fM3fDFVphJE=",
+            "dev": true
         },
         "eventemitter3": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-            "integrity":
-                "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+            "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
+            "dev": true
         },
         "exec-sh": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
-            "integrity":
-                "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+            "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+            "dev": true,
             "requires": {
                 "merge": "^1.2.0"
             }
@@ -2719,6 +2775,7 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+            "dev": true,
             "requires": {
                 "cross-spawn": "^5.0.1",
                 "get-stream": "^3.0.0",
@@ -2733,6 +2790,7 @@
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "dev": true,
             "requires": {
                 "is-posix-bracket": "^0.1.0"
             }
@@ -2741,6 +2799,7 @@
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "dev": true,
             "requires": {
                 "fill-range": "^2.1.0"
             }
@@ -2749,6 +2808,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+            "dev": true,
             "requires": {
                 "kind-of": "^1.1.0"
             }
@@ -2756,8 +2816,8 @@
         "external-editor": {
             "version": "2.2.0",
             "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-            "integrity":
-                "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+            "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+            "dev": true,
             "requires": {
                 "chardet": "^0.4.0",
                 "iconv-lite": "^0.4.17",
@@ -2768,6 +2828,7 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "dev": true,
             "requires": {
                 "is-extglob": "^1.0.0"
             }
@@ -2776,6 +2837,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+            "dev": true,
             "requires": {
                 "ansi-gray": "^0.1.1",
                 "color-support": "^1.1.3",
@@ -2786,6 +2848,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
             "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+            "dev": true,
             "requires": {
                 "bser": "^2.0.0"
             }
@@ -2794,6 +2857,7 @@
             "version": "0.8.17",
             "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
             "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+            "dev": true,
             "requires": {
                 "core-js": "^1.0.0",
                 "isomorphic-fetch": "^2.1.1",
@@ -2807,15 +2871,16 @@
                 "core-js": {
                     "version": "1.2.7",
                     "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-                    "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+                    "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+                    "dev": true
                 }
             }
         },
         "fbjs-scripts": {
             "version": "0.8.3",
             "resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-0.8.3.tgz",
-            "integrity":
-                "sha512-aUJ/uEzMIiBYuj/blLp4sVNkQQ7ZEB/lyplG1IzzOmZ83meiWecrGg5jBo4wWrxXmO4RExdtsSV1QkTjPt2Gag==",
+            "integrity": "sha512-aUJ/uEzMIiBYuj/blLp4sVNkQQ7ZEB/lyplG1IzzOmZ83meiWecrGg5jBo4wWrxXmO4RExdtsSV1QkTjPt2Gag==",
+            "dev": true,
             "requires": {
                 "ansi-colors": "^1.0.1",
                 "babel-core": "^6.7.2",
@@ -2833,6 +2898,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "dev": true,
             "requires": {
                 "escape-string-regexp": "^1.0.5"
             }
@@ -2840,13 +2906,14 @@
         "filename-regex": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+            "dev": true
         },
         "fill-range": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-            "integrity":
-                "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+            "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+            "dev": true,
             "requires": {
                 "is-number": "^2.1.0",
                 "isobject": "^2.0.0",
@@ -2859,6 +2926,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
             "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+            "dev": true,
             "requires": {
                 "debug": "2.6.9",
                 "encodeurl": "~1.0.1",
@@ -2873,6 +2941,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+            "dev": true,
             "requires": {
                 "commondir": "^1.0.1",
                 "make-dir": "^1.0.0",
@@ -2883,6 +2952,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "dev": true,
             "requires": {
                 "locate-path": "^2.0.0"
             }
@@ -2890,12 +2960,14 @@
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
         },
         "for-own": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "dev": true,
             "requires": {
                 "for-in": "^1.0.1"
             }
@@ -2904,6 +2976,7 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "dev": true,
             "requires": {
                 "map-cache": "^0.2.2"
             }
@@ -2911,12 +2984,14 @@
         "fresh": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+            "dev": true
         },
         "fs-extra": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
             "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^2.1.0",
@@ -2926,13 +3001,14 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
         },
         "fsevents": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-            "integrity":
-                "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+            "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+            "dev": true,
             "optional": true,
             "requires": {
                 "nan": "^2.9.2",
@@ -2942,26 +3018,28 @@
                 "abbrev": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-                    "integrity":
-                        "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+                    "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+                    "dev": true,
                     "optional": true
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
                 },
                 "aproba": {
                     "version": "1.2.0",
                     "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-                    "integrity":
-                        "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+                    "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+                    "dev": true,
                     "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.4",
                     "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
                     "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "delegates": "^1.0.0",
@@ -2971,13 +3049,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-                    "integrity":
-                        "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                    "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                    "dev": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -2987,35 +3066,39 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
                     "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+                    "dev": true,
                     "optional": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "resolved":
-                        "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+                    "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                     "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                    "dev": true,
                     "optional": true
                 },
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity":
-                        "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "ms": "2.0.0"
@@ -3024,27 +3107,29 @@
                 "deep-extend": {
                     "version": "0.5.1",
                     "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-                    "integrity":
-                        "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+                    "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+                    "dev": true,
                     "optional": true
                 },
                 "delegates": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
                     "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                    "dev": true,
                     "optional": true
                 },
                 "detect-libc": {
                     "version": "1.0.3",
                     "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
                     "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+                    "dev": true,
                     "optional": true
                 },
                 "fs-minipass": {
                     "version": "1.2.5",
                     "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-                    "integrity":
-                        "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+                    "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minipass": "^2.2.1"
@@ -3054,12 +3139,14 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                     "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                    "dev": true,
                     "optional": true
                 },
                 "gauge": {
                     "version": "2.7.4",
                     "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
                     "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "aproba": "^1.0.3",
@@ -3075,8 +3162,8 @@
                 "glob": {
                     "version": "7.1.2",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                    "integrity":
-                        "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -3091,13 +3178,14 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
                     "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+                    "dev": true,
                     "optional": true
                 },
                 "iconv-lite": {
                     "version": "0.4.21",
                     "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-                    "integrity":
-                        "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+                    "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "safer-buffer": "^2.1.0"
@@ -3106,8 +3194,8 @@
                 "ignore-walk": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-                    "integrity":
-                        "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+                    "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minimatch": "^3.0.4"
@@ -3117,6 +3205,7 @@
                     "version": "1.0.6",
                     "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                     "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "once": "^1.3.0",
@@ -3126,20 +3215,21 @@
                 "inherits": {
                     "version": "2.0.3",
                     "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
                 },
                 "ini": {
                     "version": "1.3.5",
                     "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-                    "integrity":
-                        "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+                    "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+                    "dev": true,
                     "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -3148,13 +3238,14 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true,
                     "optional": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                    "integrity":
-                        "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "dev": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -3162,13 +3253,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-                    "integrity":
-                        "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+                    "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+                    "dev": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -3177,8 +3269,8 @@
                 "minizlib": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-                    "integrity":
-                        "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+                    "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minipass": "^2.2.1"
@@ -3188,6 +3280,7 @@
                     "version": "0.5.1",
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "dev": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3196,13 +3289,14 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true,
                     "optional": true
                 },
                 "needle": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-                    "integrity":
-                        "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+                    "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "debug": "^2.1.2",
@@ -3213,8 +3307,8 @@
                 "node-pre-gyp": {
                     "version": "0.10.0",
                     "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
-                    "integrity":
-                        "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
+                    "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "detect-libc": "^1.0.2",
@@ -3233,6 +3327,7 @@
                     "version": "4.0.1",
                     "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
                     "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "abbrev": "1",
@@ -3242,15 +3337,15 @@
                 "npm-bundled": {
                     "version": "1.0.3",
                     "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-                    "integrity":
-                        "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+                    "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+                    "dev": true,
                     "optional": true
                 },
                 "npm-packlist": {
                     "version": "1.1.10",
                     "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-                    "integrity":
-                        "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+                    "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "ignore-walk": "^3.0.1",
@@ -3260,8 +3355,8 @@
                 "npmlog": {
                     "version": "4.1.2",
                     "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-                    "integrity":
-                        "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+                    "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "are-we-there-yet": "~1.1.2",
@@ -3273,18 +3368,21 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                    "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
                     "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true,
                     "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
                     "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "dev": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3293,19 +3391,21 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
                     "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                    "dev": true,
                     "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
                     "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+                    "dev": true,
                     "optional": true
                 },
                 "osenv": {
                     "version": "0.1.5",
                     "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-                    "integrity":
-                        "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+                    "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "os-homedir": "^1.0.0",
@@ -3316,20 +3416,21 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                     "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                    "dev": true,
                     "optional": true
                 },
                 "process-nextick-args": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-                    "integrity":
-                        "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true,
                     "optional": true
                 },
                 "rc": {
                     "version": "1.2.7",
                     "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-                    "integrity":
-                        "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+                    "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "deep-extend": "^0.5.1",
@@ -3342,6 +3443,7 @@
                             "version": "1.2.0",
                             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                            "dev": true,
                             "optional": true
                         }
                     }
@@ -3349,8 +3451,8 @@
                 "readable-stream": {
                     "version": "2.3.6",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity":
-                        "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -3365,8 +3467,8 @@
                 "rimraf": {
                     "version": "2.6.2",
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-                    "integrity":
-                        "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+                    "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "glob": "^7.0.5"
@@ -3375,46 +3477,49 @@
                 "safe-buffer": {
                     "version": "5.1.1",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                    "integrity":
-                        "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+                    "dev": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-                    "integrity":
-                        "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+                    "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+                    "dev": true,
                     "optional": true
                 },
                 "sax": {
                     "version": "1.2.4",
                     "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-                    "integrity":
-                        "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+                    "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+                    "dev": true,
                     "optional": true
                 },
                 "semver": {
                     "version": "5.5.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-                    "integrity":
-                        "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+                    "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+                    "dev": true,
                     "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
                     "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+                    "dev": true,
                     "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
                     "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+                    "dev": true,
                     "optional": true
                 },
                 "string-width": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3424,8 +3529,8 @@
                 "string_decoder": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity":
-                        "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
@@ -3435,6 +3540,7 @@
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3443,13 +3549,14 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
                     "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+                    "dev": true,
                     "optional": true
                 },
                 "tar": {
                     "version": "4.4.1",
                     "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-                    "integrity":
-                        "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+                    "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "chownr": "^1.0.1",
@@ -3465,13 +3572,14 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                     "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                    "dev": true,
                     "optional": true
                 },
                 "wide-align": {
                     "version": "1.1.2",
                     "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-                    "integrity":
-                        "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+                    "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "string-width": "^1.0.2"
@@ -3480,12 +3588,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                    "dev": true
                 },
                 "yallist": {
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-                    "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+                    "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+                    "dev": true
                 }
             }
         },
@@ -3493,6 +3603,7 @@
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
             "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+            "dev": true,
             "requires": {
                 "ansi": "^0.3.0",
                 "has-unicode": "^2.0.0",
@@ -3504,24 +3615,26 @@
         "get-caller-file": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-            "integrity":
-                "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+            "dev": true
         },
         "get-stream": {
             "version": "3.0.0",
             "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+            "dev": true
         },
         "get-value": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+            "dev": true
         },
         "glob": {
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-            "integrity":
-                "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -3535,6 +3648,7 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "dev": true,
             "requires": {
                 "glob-parent": "^2.0.0",
                 "is-glob": "^2.0.0"
@@ -3544,6 +3658,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+            "dev": true,
             "requires": {
                 "is-glob": "^2.0.0"
             }
@@ -3552,6 +3667,7 @@
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
             "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+            "dev": true,
             "requires": {
                 "min-document": "^2.19.0",
                 "process": "~0.5.1"
@@ -3560,23 +3676,26 @@
         "globals": {
             "version": "9.18.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-            "integrity":
-                "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+            "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+            "dev": true
         },
         "graceful-fs": {
             "version": "4.1.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "dev": true
         },
         "growly": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+            "dev": true
         },
         "has-ansi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
             }
@@ -3584,17 +3703,20 @@
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
         },
         "has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+            "dev": true
         },
         "has-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "dev": true,
             "requires": {
                 "get-value": "^2.0.6",
                 "has-values": "^1.0.0",
@@ -3604,7 +3726,8 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
             }
         },
@@ -3612,6 +3735,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "dev": true,
             "requires": {
                 "is-number": "^3.0.0",
                 "kind-of": "^4.0.0"
@@ -3621,6 +3745,7 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^3.0.2"
                     },
@@ -3629,6 +3754,7 @@
                             "version": "3.2.2",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
                             "requires": {
                                 "is-buffer": "^1.1.5"
                             }
@@ -3639,6 +3765,7 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -3649,6 +3776,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
             "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+            "dev": true,
             "requires": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.1"
@@ -3657,13 +3785,14 @@
         "hosted-git-info": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-            "integrity":
-                "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+            "dev": true
         },
         "http-errors": {
             "version": "1.6.3",
             "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+            "dev": true,
             "requires": {
                 "depd": "~1.1.2",
                 "inherits": "2.0.3",
@@ -3674,15 +3803,16 @@
                 "statuses": {
                     "version": "1.5.0",
                     "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-                    "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+                    "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+                    "dev": true
                 }
             }
         },
         "iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity":
-                "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
@@ -3690,18 +3820,20 @@
         "image-size": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.3.tgz",
-            "integrity":
-                "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA=="
+            "integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA==",
+            "dev": true
         },
         "imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
         },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -3710,13 +3842,14 @@
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
         },
         "inquirer": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-            "integrity":
-                "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+            "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+            "dev": true,
             "requires": {
                 "ansi-escapes": "^3.0.0",
                 "chalk": "^2.0.0",
@@ -3737,13 +3870,14 @@
                 "ansi-regex": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
                 },
                 "ansi-styles": {
                     "version": "3.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity":
-                        "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
                     "requires": {
                         "color-convert": "^1.9.0"
                     }
@@ -3751,8 +3885,8 @@
                 "chalk": {
                     "version": "2.4.1",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity":
-                        "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "dev": true,
                     "requires": {
                         "ansi-styles": "^3.2.1",
                         "escape-string-regexp": "^1.0.5",
@@ -3763,6 +3897,7 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^3.0.0"
                     }
@@ -3770,8 +3905,8 @@
                 "supports-color": {
                     "version": "5.5.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity":
-                        "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
                     "requires": {
                         "has-flag": "^3.0.0"
                     }
@@ -3781,8 +3916,8 @@
         "invariant": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-            "integrity":
-                "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.0.0"
             }
@@ -3790,12 +3925,14 @@
         "invert-kv": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
         },
         "is-accessor-descriptor": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -3804,6 +3941,7 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -3813,18 +3951,20 @@
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
         },
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity":
-                "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true
         },
         "is-builtin-module": {
             "version": "1.0.0",
             "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+            "dev": true,
             "requires": {
                 "builtin-modules": "^1.0.0"
             }
@@ -3833,6 +3973,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -3841,6 +3982,7 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -3850,8 +3992,8 @@
         "is-descriptor": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-            "integrity":
-                "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+            "dev": true,
             "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -3861,25 +4003,28 @@
                 "kind-of": {
                     "version": "5.1.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity":
-                        "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
                 }
             }
         },
         "is-directory": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-            "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+            "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+            "dev": true
         },
         "is-dotfile": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+            "dev": true
         },
         "is-equal-shallow": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "dev": true,
             "requires": {
                 "is-primitive": "^2.0.0"
             }
@@ -3887,17 +4032,20 @@
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
         },
         "is-extglob": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+            "dev": true
         },
         "is-finite": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+            "dev": true,
             "requires": {
                 "number-is-nan": "^1.0.0"
             }
@@ -3905,12 +4053,14 @@
         "is-fullwidth-code-point": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
         },
         "is-glob": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "dev": true,
             "requires": {
                 "is-extglob": "^1.0.0"
             }
@@ -3919,6 +4069,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -3927,6 +4078,7 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -3936,8 +4088,8 @@
         "is-plain-object": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-            "integrity":
-                "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
             },
@@ -3945,50 +4097,58 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
             }
         },
         "is-posix-bracket": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+            "dev": true
         },
         "is-primitive": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+            "dev": true
         },
         "is-promise": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+            "dev": true
         },
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
         },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-            "integrity":
-                "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true
         },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
         },
         "isobject": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "dev": true,
             "requires": {
                 "isarray": "1.0.0"
             }
@@ -3997,6 +4157,7 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
             "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+            "dev": true,
             "requires": {
                 "node-fetch": "^1.0.1",
                 "whatwg-fetch": ">=0.10.0"
@@ -4005,8 +4166,8 @@
                 "node-fetch": {
                     "version": "1.7.3",
                     "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-                    "integrity":
-                        "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+                    "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+                    "dev": true,
                     "requires": {
                         "encoding": "^0.1.11",
                         "is-stream": "^1.0.1"
@@ -4018,6 +4179,7 @@
             "version": "23.2.0",
             "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
             "integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
+            "dev": true,
             "requires": {
                 "detect-newline": "^2.1.0"
             }
@@ -4025,8 +4187,8 @@
         "jest-haste-map": {
             "version": "23.5.0",
             "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.5.0.tgz",
-            "integrity":
-                "sha512-bt9Swigb6KZ6ZQq/fQDUwdUeHenVvZ6G/lKwJjwRGp+Fap8D4B3bND3FaeJg7vXVsLX8hXshRArbVxLop/5wLw==",
+            "integrity": "sha512-bt9Swigb6KZ6ZQq/fQDUwdUeHenVvZ6G/lKwJjwRGp+Fap8D4B3bND3FaeJg7vXVsLX8hXshRArbVxLop/5wLw==",
+            "dev": true,
             "requires": {
                 "fb-watchman": "^2.0.0",
                 "graceful-fs": "^4.1.11",
@@ -4041,12 +4203,14 @@
         "jest-serializer": {
             "version": "23.0.1",
             "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
-            "integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU="
+            "integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=",
+            "dev": true
         },
         "jest-worker": {
             "version": "23.2.0",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
             "integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
+            "dev": true,
             "requires": {
                 "merge-stream": "^1.0.1"
             }
@@ -4054,13 +4218,14 @@
         "js-tokens": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "dev": true
         },
         "js-yaml": {
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-            "integrity":
-                "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+            "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+            "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -4069,18 +4234,20 @@
         "jsesc": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+            "dev": true
         },
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity":
-                "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
         },
         "json-stable-stringify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true,
             "requires": {
                 "jsonify": "~0.0.0"
             }
@@ -4088,12 +4255,14 @@
         "json5": {
             "version": "0.5.1",
             "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+            "dev": true
         },
         "jsonfile": {
             "version": "2.4.0",
             "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
             "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.6"
             }
@@ -4101,17 +4270,20 @@
         "jsonify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
         },
         "kind-of": {
             "version": "1.1.0",
             "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-            "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
+            "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+            "dev": true
         },
         "klaw": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
             "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.9"
             }
@@ -4120,6 +4292,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "dev": true,
             "requires": {
                 "invert-kv": "^1.0.0"
             }
@@ -4128,6 +4301,7 @@
             "version": "2.0.0",
             "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
             "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "parse-json": "^2.2.0",
@@ -4139,6 +4313,7 @@
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                    "dev": true,
                     "requires": {
                         "error-ex": "^1.2.0"
                     }
@@ -4149,6 +4324,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
             "requires": {
                 "p-locate": "^2.0.0",
                 "path-exists": "^3.0.0"
@@ -4157,34 +4333,38 @@
         "lodash": {
             "version": "4.17.11",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity":
-                "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "dev": true
         },
         "lodash.pad": {
             "version": "4.5.1",
             "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-            "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA="
+            "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
+            "dev": true
         },
         "lodash.padend": {
             "version": "4.6.1",
             "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-            "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
+            "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+            "dev": true
         },
         "lodash.padstart": {
             "version": "4.6.1",
             "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-            "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
+            "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
+            "dev": true
         },
         "lodash.throttle": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-            "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+            "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
+            "dev": true
         },
         "loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-            "integrity":
-                "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
             "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
@@ -4192,8 +4372,8 @@
         "lru-cache": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-            "integrity":
-                "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+            "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+            "dev": true,
             "requires": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
@@ -4202,8 +4382,8 @@
         "make-dir": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-            "integrity":
-                "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+            "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+            "dev": true,
             "requires": {
                 "pify": "^3.0.0"
             },
@@ -4211,7 +4391,8 @@
                 "pify": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
                 }
             }
         },
@@ -4219,6 +4400,7 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
             "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+            "dev": true,
             "requires": {
                 "tmpl": "1.0.x"
             }
@@ -4226,12 +4408,14 @@
         "map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+            "dev": true
         },
         "map-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "dev": true,
             "requires": {
                 "object-visit": "^1.0.0"
             }
@@ -4239,12 +4423,14 @@
         "math-random": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+            "dev": true
         },
         "mem": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+            "dev": true,
             "requires": {
                 "mimic-fn": "^1.0.0"
             }
@@ -4252,12 +4438,14 @@
         "merge": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-            "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+            "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+            "dev": true
         },
         "merge-stream": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+            "dev": true,
             "requires": {
                 "readable-stream": "^2.0.1"
             }
@@ -4265,8 +4453,8 @@
         "metro": {
             "version": "0.45.6",
             "resolved": "https://registry.npmjs.org/metro/-/metro-0.45.6.tgz",
-            "integrity":
-                "sha512-+RinU6Qcea/zX9xxfrgmeFBwJ3tsdgLyBJm4tQOmusU4kE8YEE4LQ3IGG60qk3wzYloflMB/8ilIGG4Z/gz2Ew==",
+            "integrity": "sha512-+RinU6Qcea/zX9xxfrgmeFBwJ3tsdgLyBJm4tQOmusU4kE8YEE4LQ3IGG60qk3wzYloflMB/8ilIGG4Z/gz2Ew==",
+            "dev": true,
             "requires": {
                 "@babel/core": "^7.0.0",
                 "@babel/generator": "^7.0.0",
@@ -4322,12 +4510,14 @@
                 "mime-db": {
                     "version": "1.23.0",
                     "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-                    "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
+                    "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
+                    "dev": true
                 },
                 "mime-types": {
                     "version": "2.1.11",
                     "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
                     "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+                    "dev": true,
                     "requires": {
                         "mime-db": "~1.23.0"
                     }
@@ -4337,8 +4527,8 @@
         "metro-babel-register": {
             "version": "0.45.6",
             "resolved": "https://registry.npmjs.org/metro-babel-register/-/metro-babel-register-0.45.6.tgz",
-            "integrity":
-                "sha512-Io8JinYIzGcXiTaO7o0DGw8wFcAiITTb7mLh3lbuJd9PndbPOo+jhrHkTsNtXc9MRHiT4KbEheXJ/QoeLKJK/Q==",
+            "integrity": "sha512-Io8JinYIzGcXiTaO7o0DGw8wFcAiITTb7mLh3lbuJd9PndbPOo+jhrHkTsNtXc9MRHiT4KbEheXJ/QoeLKJK/Q==",
+            "dev": true,
             "requires": {
                 "@babel/core": "^7.0.0",
                 "@babel/plugin-proposal-class-properties": "^7.0.0",
@@ -4356,10 +4546,9 @@
         },
         "metro-babel7-plugin-react-transform": {
             "version": "0.45.6",
-            "resolved":
-                "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.45.6.tgz",
-            "integrity":
-                "sha512-NsVKqiBaF+Tm3FXzqiEExl9iJG+EimbpQP5h9ygxBE4AsYRc2S3X/YD/1ds3RTHMgfhinWVaus+DrG5OqK5mTA==",
+            "resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.45.6.tgz",
+            "integrity": "sha512-NsVKqiBaF+Tm3FXzqiEExl9iJG+EimbpQP5h9ygxBE4AsYRc2S3X/YD/1ds3RTHMgfhinWVaus+DrG5OqK5mTA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.0.0"
             }
@@ -4367,8 +4556,8 @@
         "metro-cache": {
             "version": "0.45.6",
             "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.45.6.tgz",
-            "integrity":
-                "sha512-v7q2pLsI7oABEjpwPJwTd7ufwKvpctVOddcffI/2hRhuJC/seLlqkRt7kv+Q/WfaR9X4KLcEoIjZmgNy4cw1ag==",
+            "integrity": "sha512-v7q2pLsI7oABEjpwPJwTd7ufwKvpctVOddcffI/2hRhuJC/seLlqkRt7kv+Q/WfaR9X4KLcEoIjZmgNy4cw1ag==",
+            "dev": true,
             "requires": {
                 "jest-serializer": "23.0.1",
                 "metro-core": "0.45.6",
@@ -4379,8 +4568,8 @@
         "metro-config": {
             "version": "0.45.6",
             "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.45.6.tgz",
-            "integrity":
-                "sha512-ZhVtkpXhOi+qWi7vdE3HGIhyyBT1wtIukQuxTMwLTUluv2/1DClo/uX9inmf++CmOhOpU7QpqrMzl6vf+AwnOg==",
+            "integrity": "sha512-ZhVtkpXhOi+qWi7vdE3HGIhyyBT1wtIukQuxTMwLTUluv2/1DClo/uX9inmf++CmOhOpU7QpqrMzl6vf+AwnOg==",
+            "dev": true,
             "requires": {
                 "cosmiconfig": "^5.0.5",
                 "metro": "0.45.6",
@@ -4391,8 +4580,8 @@
         "metro-core": {
             "version": "0.45.6",
             "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.45.6.tgz",
-            "integrity":
-                "sha512-M0YkGnkjStdCsSNYVW+aVlJ4WjwcqjIhQV+VzEnGZYdyo6cMi9MxUZ69iV2jIxd3LAeaQQaNe8OQtQp8dfIh/g==",
+            "integrity": "sha512-M0YkGnkjStdCsSNYVW+aVlJ4WjwcqjIhQV+VzEnGZYdyo6cMi9MxUZ69iV2jIxd3LAeaQQaNe8OQtQp8dfIh/g==",
+            "dev": true,
             "requires": {
                 "jest-haste-map": "23.5.0",
                 "lodash.throttle": "^4.1.1",
@@ -4403,24 +4592,23 @@
         "metro-memory-fs": {
             "version": "0.45.6",
             "resolved": "https://registry.npmjs.org/metro-memory-fs/-/metro-memory-fs-0.45.6.tgz",
-            "integrity":
-                "sha512-YAGoNQVTM/vl65jR/ztucAZJIk0ejD3INZT0LiISRULBt6Rxfiqa22v5GG0Enq+95vlgmt26g+auHM2nxTUInQ=="
+            "integrity": "sha512-YAGoNQVTM/vl65jR/ztucAZJIk0ejD3INZT0LiISRULBt6Rxfiqa22v5GG0Enq+95vlgmt26g+auHM2nxTUInQ==",
+            "dev": true
         },
         "metro-minify-uglify": {
             "version": "0.45.6",
             "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.45.6.tgz",
-            "integrity":
-                "sha512-l+lZ7Gg6CN9XddgmwAbo7zOLT2QB9a6VALXLzmvr6gB1mc6SBZwtAh+hARvdymtcr1CgbaWADZPAA+W3oQZH4g==",
+            "integrity": "sha512-l+lZ7Gg6CN9XddgmwAbo7zOLT2QB9a6VALXLzmvr6gB1mc6SBZwtAh+hARvdymtcr1CgbaWADZPAA+W3oQZH4g==",
+            "dev": true,
             "requires": {
                 "uglify-es": "^3.1.9"
             }
         },
         "metro-react-native-babel-preset": {
             "version": "0.45.6",
-            "resolved":
-                "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.45.6.tgz",
-            "integrity":
-                "sha512-qh+iXlV2tDfvHYbhh1meihxnzXXXB8nF1fi8z2HFxqYDkFBM48XewXO6mLz97PL8lmuTGvX/2dYVuFtriENw1w==",
+            "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.45.6.tgz",
+            "integrity": "sha512-qh+iXlV2tDfvHYbhh1meihxnzXXXB8nF1fi8z2HFxqYDkFBM48XewXO6mLz97PL8lmuTGvX/2dYVuFtriENw1w==",
+            "dev": true,
             "requires": {
                 "@babel/plugin-proposal-class-properties": "^7.0.0",
                 "@babel/plugin-proposal-export-default-from": "^7.0.0",
@@ -4461,8 +4649,8 @@
         "metro-resolver": {
             "version": "0.45.6",
             "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.45.6.tgz",
-            "integrity":
-                "sha512-RY4tqKxSEz4ahLPaJlx30x6vG8HVyLT3w5aUDcyB5B2eQH3ckLnyUYUpd0sT7HFoJ1T5U5DFtWvS3P4yJcRB7A==",
+            "integrity": "sha512-RY4tqKxSEz4ahLPaJlx30x6vG8HVyLT3w5aUDcyB5B2eQH3ckLnyUYUpd0sT7HFoJ1T5U5DFtWvS3P4yJcRB7A==",
+            "dev": true,
             "requires": {
                 "absolute-path": "^0.0.0"
             }
@@ -4470,8 +4658,8 @@
         "metro-source-map": {
             "version": "0.45.6",
             "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.45.6.tgz",
-            "integrity":
-                "sha512-FBubSEEitGrvUeuCPVwXTJX7Y1WjFhsUHickqQE+mXplOgREyeZ7o80ffqEWitfsMUQN9385LxIPmAdPzQXLsQ==",
+            "integrity": "sha512-FBubSEEitGrvUeuCPVwXTJX7Y1WjFhsUHickqQE+mXplOgREyeZ7o80ffqEWitfsMUQN9385LxIPmAdPzQXLsQ==",
+            "dev": true,
             "requires": {
                 "source-map": "^0.5.6"
             }
@@ -4480,6 +4668,7 @@
             "version": "2.3.11",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "dev": true,
             "requires": {
                 "arr-diff": "^2.0.0",
                 "array-unique": "^0.2.1",
@@ -4500,6 +4689,7 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                    "dev": true,
                     "requires": {
                         "arr-flatten": "^1.0.1"
                     }
@@ -4508,6 +4698,7 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -4517,20 +4708,20 @@
         "mime": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity":
-                "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "dev": true
         },
         "mime-db": {
             "version": "1.36.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-            "integrity":
-                "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+            "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+            "dev": true
         },
         "mime-types": {
             "version": "2.1.20",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-            "integrity":
-                "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+            "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+            "dev": true,
             "requires": {
                 "mime-db": "~1.36.0"
             }
@@ -4538,13 +4729,14 @@
         "mimic-fn": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-            "integrity":
-                "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "dev": true
         },
         "min-document": {
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
             "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+            "dev": true,
             "requires": {
                 "dom-walk": "^0.1.0"
             }
@@ -4552,8 +4744,8 @@
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity":
-                "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -4561,13 +4753,14 @@
         "minimist": {
             "version": "1.2.0",
             "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "dev": true
         },
         "mixin-deep": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-            "integrity":
-                "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "dev": true,
             "requires": {
                 "for-in": "^1.0.2",
                 "is-extendable": "^1.0.1"
@@ -4576,8 +4769,8 @@
                 "is-extendable": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                    "integrity":
-                        "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -4588,6 +4781,7 @@
             "version": "0.5.1",
             "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
             "requires": {
                 "minimist": "0.0.8"
             },
@@ -4595,15 +4789,16 @@
                 "minimist": {
                     "version": "0.0.8",
                     "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
                 }
             }
         },
         "morgan": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
-            "integrity":
-                "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
+            "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
+            "dev": true,
             "requires": {
                 "basic-auth": "~2.0.0",
                 "debug": "2.6.9",
@@ -4615,25 +4810,27 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
         },
         "mute-stream": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "dev": true
         },
         "nan": {
             "version": "2.11.1",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-            "integrity":
-                "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+            "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+            "dev": true,
             "optional": true
         },
         "nanomatch": {
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-            "integrity":
-                "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+            "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+            "dev": true,
             "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
@@ -4651,17 +4848,20 @@
                 "arr-diff": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
                 },
                 "array-unique": {
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
                 },
                 "extend-shallow": {
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
                     "requires": {
                         "assign-symbols": "^1.0.0",
                         "is-extendable": "^1.0.1"
@@ -4670,8 +4870,8 @@
                 "is-extendable": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                    "integrity":
-                        "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -4679,37 +4879,40 @@
                 "kind-of": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity":
-                        "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
                 }
             }
         },
         "negotiator": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+            "dev": true
         },
         "node-fetch": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
-            "integrity":
-                "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
+            "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==",
+            "dev": true
         },
         "node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+            "dev": true
         },
         "node-modules-regexp": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-            "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
+            "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+            "dev": true
         },
         "node-notifier": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-            "integrity":
-                "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+            "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+            "dev": true,
             "requires": {
                 "growly": "^1.3.0",
                 "semver": "^5.4.1",
@@ -4720,8 +4923,8 @@
         "normalize-package-data": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-            "integrity":
-                "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+            "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+            "dev": true,
             "requires": {
                 "hosted-git-info": "^2.1.4",
                 "is-builtin-module": "^1.0.0",
@@ -4733,6 +4936,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "dev": true,
             "requires": {
                 "remove-trailing-separator": "^1.0.1"
             }
@@ -4741,6 +4945,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
             "requires": {
                 "path-key": "^2.0.0"
             }
@@ -4749,6 +4954,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
             "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
+            "dev": true,
             "requires": {
                 "ansi": "~0.3.1",
                 "are-we-there-yet": "~1.1.2",
@@ -4758,23 +4964,26 @@
         "nullthrows": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.0.tgz",
-            "integrity":
-                "sha512-YoigDq49JRqVCUlb4XlwZirXQiNCoXdwoyfklXJAEYHN+XKHWgDkrcWxNgxEtP7N+XF9Akp7Lr6wLq8HZxLttw=="
+            "integrity": "sha512-YoigDq49JRqVCUlb4XlwZirXQiNCoXdwoyfklXJAEYHN+XKHWgDkrcWxNgxEtP7N+XF9Akp7Lr6wLq8HZxLttw==",
+            "dev": true
         },
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
         },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
         },
         "object-copy": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "dev": true,
             "requires": {
                 "copy-descriptor": "^0.1.0",
                 "define-property": "^0.2.5",
@@ -4785,6 +4994,7 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -4793,6 +5003,7 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -4803,6 +5014,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
             },
@@ -4810,7 +5022,8 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
             }
         },
@@ -4818,6 +5031,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "dev": true,
             "requires": {
                 "for-own": "^0.1.4",
                 "is-extendable": "^0.1.1"
@@ -4827,6 +5041,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
             },
@@ -4834,7 +5049,8 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
             }
         },
@@ -4842,6 +5058,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
             "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "dev": true,
             "requires": {
                 "ee-first": "1.1.1"
             }
@@ -4849,12 +5066,14 @@
         "on-headers": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-            "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+            "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
+            "dev": true
         },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -4863,6 +5082,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "dev": true,
             "requires": {
                 "mimic-fn": "^1.0.0"
             }
@@ -4871,6 +5091,7 @@
             "version": "3.0.3",
             "resolved": "http://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
             "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
+            "dev": true,
             "requires": {
                 "object-assign": "^4.0.1"
             }
@@ -4879,6 +5100,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "dev": true,
             "requires": {
                 "minimist": "~0.0.1",
                 "wordwrap": "~0.0.2"
@@ -4887,30 +5109,34 @@
                 "minimist": {
                     "version": "0.0.10",
                     "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                    "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+                    "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                    "dev": true
                 },
                 "wordwrap": {
                     "version": "0.0.3",
                     "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                    "dev": true
                 }
             }
         },
         "options": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-            "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+            "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
+            "dev": true
         },
         "os-homedir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
         },
         "os-locale": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-            "integrity":
-                "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+            "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+            "dev": true,
             "requires": {
                 "execa": "^0.7.0",
                 "lcid": "^1.0.0",
@@ -4920,18 +5146,20 @@
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
         },
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
         },
         "p-limit": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-            "integrity":
-                "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+            "dev": true,
             "requires": {
                 "p-try": "^1.0.0"
             }
@@ -4940,6 +5168,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true,
             "requires": {
                 "p-limit": "^1.1.0"
             }
@@ -4947,12 +5176,14 @@
         "p-try": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "dev": true
         },
         "parse-glob": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "dev": true,
             "requires": {
                 "glob-base": "^0.3.0",
                 "is-dotfile": "^1.0.0",
@@ -4964,6 +5195,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
             "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "dev": true,
             "requires": {
                 "error-ex": "^1.3.1",
                 "json-parse-better-errors": "^1.0.1"
@@ -4972,38 +5204,44 @@
         "parseurl": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-            "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+            "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+            "dev": true
         },
         "pascalcase": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+            "dev": true
         },
         "path-exists": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
         },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
         },
         "path-key": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
         },
         "path-parse": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity":
-                "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
         },
         "path-type": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
             "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+            "dev": true,
             "requires": {
                 "pify": "^2.0.0"
             }
@@ -5011,18 +5249,20 @@
         "pegjs": {
             "version": "0.10.0",
             "resolved": "http://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
-            "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
+            "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
+            "dev": true
         },
         "pify": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
         },
         "pirates": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
-            "integrity":
-                "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
+            "integrity": "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
+            "dev": true,
             "requires": {
                 "node-modules-regexp": "^1.0.0"
             }
@@ -5031,6 +5271,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+            "dev": true,
             "requires": {
                 "find-up": "^2.1.0"
             }
@@ -5038,8 +5279,8 @@
         "plist": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-            "integrity":
-                "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+            "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+            "dev": true,
             "requires": {
                 "base64-js": "^1.2.3",
                 "xmlbuilder": "^9.0.7",
@@ -5050,6 +5291,7 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+            "dev": true,
             "requires": {
                 "ansi-cyan": "^0.1.1",
                 "ansi-red": "^0.1.1",
@@ -5061,40 +5303,44 @@
         "posix-character-classes": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+            "dev": true
         },
         "preserve": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+            "dev": true
         },
         "pretty-format": {
             "version": "4.3.1",
             "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
-            "integrity": "sha1-UwvlxCs8BbNkFKeipDN6qArNDo0="
+            "integrity": "sha1-UwvlxCs8BbNkFKeipDN6qArNDo0=",
+            "dev": true
         },
         "private": {
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "integrity":
-                "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+            "dev": true
         },
         "process": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-            "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+            "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
+            "dev": true
         },
         "process-nextick-args": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity":
-                "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "dev": true
         },
         "promise": {
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-            "integrity":
-                "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+            "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+            "dev": true,
             "requires": {
                 "asap": "~2.0.3"
             }
@@ -5102,8 +5348,8 @@
         "prop-types": {
             "version": "15.6.2",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-            "integrity":
-                "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+            "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.3.1",
                 "object-assign": "^4.1.1"
@@ -5112,13 +5358,14 @@
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
         },
         "randomatic": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
-            "integrity":
-                "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+            "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+            "dev": true,
             "requires": {
                 "is-number": "^4.0.0",
                 "kind-of": "^6.0.0",
@@ -5128,27 +5375,28 @@
                 "is-number": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-                    "integrity":
-                        "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
                 },
                 "kind-of": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity":
-                        "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
                 }
             }
         },
         "range-parser": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+            "dev": true
         },
         "react": {
             "version": "16.5.2",
             "resolved": "https://registry.npmjs.org/react/-/react-16.5.2.tgz",
-            "integrity":
-                "sha512-FDCSVd3DjVTmbEAjUNX6FgfAmQ+ypJfHUsqUJOYNCBUp1h8lqmtC+0mXJ+JjsWx4KAVTkk1vKd1hLQPvEviSuw==",
+            "integrity": "sha512-FDCSVd3DjVTmbEAjUNX6FgfAmQ+ypJfHUsqUJOYNCBUp1h8lqmtC+0mXJ+JjsWx4KAVTkk1vKd1hLQPvEviSuw==",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -5158,22 +5406,21 @@
         },
         "react-clone-referenced-element": {
             "version": "1.1.0",
-            "resolved":
-                "https://registry.npmjs.org/react-clone-referenced-element/-/react-clone-referenced-element-1.1.0.tgz",
-            "integrity":
-                "sha512-FKOsfKbBkPxYE8576EM6uAfHC4rnMpLyH6/TJUL4WcHUEB3EUn8AxPjnnV/IiwSSzsClvHYK+sDELKN/EJ0WYg=="
+            "resolved": "https://registry.npmjs.org/react-clone-referenced-element/-/react-clone-referenced-element-1.1.0.tgz",
+            "integrity": "sha512-FKOsfKbBkPxYE8576EM6uAfHC4rnMpLyH6/TJUL4WcHUEB3EUn8AxPjnnV/IiwSSzsClvHYK+sDELKN/EJ0WYg==",
+            "dev": true
         },
         "react-deep-force-update": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-1.1.2.tgz",
-            "integrity":
-                "sha512-WUSQJ4P/wWcusaH+zZmbECOk7H5N2pOIl0vzheeornkIMhu+qrNdGFm0bDZLCb0hSF0jf/kH1SgkNGfBdTc4wA=="
+            "integrity": "sha512-WUSQJ4P/wWcusaH+zZmbECOk7H5N2pOIl0vzheeornkIMhu+qrNdGFm0bDZLCb0hSF0jf/kH1SgkNGfBdTc4wA==",
+            "dev": true
         },
         "react-devtools-core": {
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.3.4.tgz",
-            "integrity":
-                "sha512-6lsBDRInT9jU8Ya8bnKWJSsnaGg/xk1ZSfvhc/dHc3n2CUTMfGlqm2tGeZQ9WEoe0Y2K7Lg90Kvb1E8anLePaQ==",
+            "integrity": "sha512-6lsBDRInT9jU8Ya8bnKWJSsnaGg/xk1ZSfvhc/dHc3n2CUTMfGlqm2tGeZQ9WEoe0Y2K7Lg90Kvb1E8anLePaQ==",
+            "dev": true,
             "requires": {
                 "shell-quote": "^1.6.1",
                 "ws": "^3.3.1"
@@ -5182,14 +5429,14 @@
                 "ultron": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-                    "integrity":
-                        "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+                    "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+                    "dev": true
                 },
                 "ws": {
                     "version": "3.3.3",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-                    "integrity":
-                        "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+                    "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+                    "dev": true,
                     "requires": {
                         "async-limiter": "~1.0.0",
                         "safe-buffer": "~5.1.0",
@@ -5201,8 +5448,8 @@
         "react-native": {
             "version": "0.57.1",
             "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.57.1.tgz",
-            "integrity":
-                "sha512-d+bRxIFjCrvXVbvPhuyLvE8NSiYKzldBzL+sJjSGxNqOOb2UIjLfB1BGUkI3n3X7KAYEUp4KUhT7YfA2qsRi/w==",
+            "integrity": "sha512-d+bRxIFjCrvXVbvPhuyLvE8NSiYKzldBzL+sJjSGxNqOOb2UIjLfB1BGUkI3n3X7KAYEUp4KUhT7YfA2qsRi/w==",
+            "dev": true,
             "requires": {
                 "absolute-path": "^0.0.0",
                 "art": "^0.10.0",
@@ -5261,6 +5508,7 @@
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",
             "integrity": "sha1-nb/Z2SdSjDqp9ETkVYw3gwq4wmo=",
+            "dev": true,
             "requires": {
                 "lodash": "^4.6.1",
                 "react-deep-force-update": "^1.0.0"
@@ -5269,13 +5517,14 @@
         "react-timer-mixin": {
             "version": "0.13.4",
             "resolved": "https://registry.npmjs.org/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz",
-            "integrity":
-                "sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q=="
+            "integrity": "sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q==",
+            "dev": true
         },
         "react-transform-hmr": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz",
             "integrity": "sha1-4aQL0Krvxy6N/Xp82gmvhQZjl7s=",
+            "dev": true,
             "requires": {
                 "global": "^4.3.0",
                 "react-proxy": "^1.1.7"
@@ -5285,6 +5534,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
             "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+            "dev": true,
             "requires": {
                 "load-json-file": "^2.0.0",
                 "normalize-package-data": "^2.3.2",
@@ -5295,6 +5545,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
             "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+            "dev": true,
             "requires": {
                 "find-up": "^2.0.0",
                 "read-pkg": "^2.0.0"
@@ -5303,8 +5554,8 @@
         "readable-stream": {
             "version": "2.3.6",
             "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-            "integrity":
-                "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -5318,15 +5569,14 @@
         "regenerate": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-            "integrity":
-                "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+            "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+            "dev": true
         },
         "regenerate-unicode-properties": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
-            "integrity":
-                "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
+            "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+            "dev": true,
             "requires": {
                 "regenerate": "^1.4.0"
             }
@@ -5334,14 +5584,14 @@
         "regenerator-runtime": {
             "version": "0.11.1",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-            "integrity":
-                "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+            "dev": true
         },
         "regenerator-transform": {
             "version": "0.10.1",
             "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-            "integrity":
-                "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+            "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.18.0",
                 "babel-types": "^6.19.0",
@@ -5351,8 +5601,8 @@
         "regex-cache": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity":
-                "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+            "dev": true,
             "requires": {
                 "is-equal-shallow": "^0.1.3"
             }
@@ -5360,8 +5610,8 @@
         "regex-not": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-            "integrity":
-                "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.2",
                 "safe-regex": "^1.1.0"
@@ -5371,6 +5621,7 @@
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
                     "requires": {
                         "assign-symbols": "^1.0.0",
                         "is-extendable": "^1.0.1"
@@ -5379,8 +5630,8 @@
                 "is-extendable": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                    "integrity":
-                        "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -5390,8 +5641,8 @@
         "regexpu-core": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
-            "integrity":
-                "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+            "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+            "dev": true,
             "requires": {
                 "regenerate": "^1.4.0",
                 "regenerate-unicode-properties": "^7.0.0",
@@ -5404,14 +5655,14 @@
         "regjsgen": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
-            "integrity":
-                "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
+            "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+            "dev": true
         },
         "regjsparser": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
-            "integrity":
-                "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+            "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+            "dev": true,
             "requires": {
                 "jsesc": "~0.5.0"
             },
@@ -5419,30 +5670,34 @@
                 "jsesc": {
                     "version": "0.5.0",
                     "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
                 }
             }
         },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
         },
         "repeat-element": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-            "integrity":
-                "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+            "dev": true
         },
         "repeat-string": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
         },
         "repeating": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+            "dev": true,
             "requires": {
                 "is-finite": "^1.0.0"
             }
@@ -5450,18 +5705,20 @@
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
         },
         "require-main-filename": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
         },
         "resolve": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-            "integrity":
-                "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+            "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+            "dev": true,
             "requires": {
                 "path-parse": "^1.0.5"
             }
@@ -5469,12 +5726,14 @@
         "resolve-url": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+            "dev": true
         },
         "restore-cursor": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "dev": true,
             "requires": {
                 "onetime": "^2.0.0",
                 "signal-exit": "^3.0.2"
@@ -5483,14 +5742,14 @@
         "ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-            "integrity":
-                "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
         },
         "rimraf": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity":
-                "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "dev": true,
             "requires": {
                 "glob": "^7.0.5"
             }
@@ -5498,13 +5757,14 @@
         "rsvp": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-            "integrity":
-                "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+            "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+            "dev": true
         },
         "run-async": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+            "dev": true,
             "requires": {
                 "is-promise": "^2.1.0"
             }
@@ -5512,12 +5772,14 @@
         "rx-lite": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-            "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+            "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+            "dev": true
         },
         "rx-lite-aggregates": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
             "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+            "dev": true,
             "requires": {
                 "rx-lite": "*"
             }
@@ -5525,13 +5787,14 @@
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity":
-                "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "safe-regex": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "dev": true,
             "requires": {
                 "ret": "~0.1.10"
             }
@@ -5539,13 +5802,14 @@
         "safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity":
-                "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "sane": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
             "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
+            "dev": true,
             "requires": {
                 "anymatch": "^2.0.0",
                 "capture-exit": "^1.2.0",
@@ -5561,18 +5825,20 @@
                 "arr-diff": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
                 },
                 "array-unique": {
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
                 },
                 "braces": {
                     "version": "2.3.2",
                     "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity":
-                        "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
                     "requires": {
                         "arr-flatten": "^1.1.0",
                         "array-unique": "^0.3.2",
@@ -5590,6 +5856,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -5600,6 +5867,7 @@
                     "version": "2.1.4",
                     "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
                     "requires": {
                         "debug": "^2.3.3",
                         "define-property": "^0.2.5",
@@ -5614,6 +5882,7 @@
                             "version": "0.2.5",
                             "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
                             "requires": {
                                 "is-descriptor": "^0.1.0"
                             }
@@ -5622,15 +5891,16 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
                             "version": "0.1.6",
-                            "resolved":
-                                "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
                             "requires": {
                                 "kind-of": "^3.0.2"
                             },
@@ -5639,6 +5909,7 @@
                                     "version": "3.2.2",
                                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
                                     "requires": {
                                         "is-buffer": "^1.1.5"
                                     }
@@ -5649,6 +5920,7 @@
                             "version": "0.1.4",
                             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
                             "requires": {
                                 "kind-of": "^3.0.2"
                             },
@@ -5657,6 +5929,7 @@
                                     "version": "3.2.2",
                                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
                                     "requires": {
                                         "is-buffer": "^1.1.5"
                                     }
@@ -5666,8 +5939,8 @@
                         "is-descriptor": {
                             "version": "0.1.6",
                             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                            "integrity":
-                                "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
                             "requires": {
                                 "is-accessor-descriptor": "^0.1.6",
                                 "is-data-descriptor": "^0.1.4",
@@ -5677,8 +5950,8 @@
                         "kind-of": {
                             "version": "5.1.0",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                            "integrity":
-                                "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
                         }
                     }
                 },
@@ -5686,6 +5959,7 @@
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
                     "requires": {
                         "assign-symbols": "^1.0.0",
                         "is-extendable": "^1.0.1"
@@ -5694,8 +5968,8 @@
                         "is-extendable": {
                             "version": "1.0.1",
                             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                            "integrity":
-                                "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                            "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                            "dev": true,
                             "requires": {
                                 "is-plain-object": "^2.0.4"
                             }
@@ -5705,8 +5979,8 @@
                 "extglob": {
                     "version": "2.0.4",
                     "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-                    "integrity":
-                        "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
                     "requires": {
                         "array-unique": "^0.3.2",
                         "define-property": "^1.0.0",
@@ -5722,6 +5996,7 @@
                             "version": "1.0.0",
                             "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
                             "requires": {
                                 "is-descriptor": "^1.0.0"
                             }
@@ -5730,6 +6005,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -5740,6 +6016,7 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
                     "requires": {
                         "extend-shallow": "^2.0.1",
                         "is-number": "^3.0.0",
@@ -5751,6 +6028,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -5760,8 +6038,8 @@
                 "is-accessor-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -5769,8 +6047,8 @@
                 "is-data-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -5778,8 +6056,8 @@
                 "is-descriptor": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity":
-                        "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -5790,6 +6068,7 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^3.0.2"
                     },
@@ -5798,6 +6077,7 @@
                             "version": "3.2.2",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
                             "requires": {
                                 "is-buffer": "^1.1.5"
                             }
@@ -5807,19 +6087,20 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 },
                 "kind-of": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity":
-                        "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
                 },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-                    "integrity":
-                        "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
                     "requires": {
                         "arr-diff": "^4.0.0",
                         "array-unique": "^0.3.2",
@@ -5841,13 +6122,14 @@
         "sax": {
             "version": "1.1.6",
             "resolved": "http://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
-            "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
+            "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA=",
+            "dev": true
         },
         "schedule": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/schedule/-/schedule-0.5.0.tgz",
-            "integrity":
-                "sha512-HUcJicG5Ou8xfR//c2rPT0lPIRR09vVvN81T9fqfVgBmhERUbDEQoYKjpBxbueJnCPpSu2ujXzOnRQt6x9o/jw==",
+            "integrity": "sha512-HUcJicG5Ou8xfR//c2rPT0lPIRR09vVvN81T9fqfVgBmhERUbDEQoYKjpBxbueJnCPpSu2ujXzOnRQt6x9o/jw==",
+            "dev": true,
             "requires": {
                 "object-assign": "^4.1.1"
             }
@@ -5855,14 +6137,14 @@
         "semver": {
             "version": "5.5.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-            "integrity":
-                "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+            "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+            "dev": true
         },
         "send": {
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-            "integrity":
-                "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+            "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+            "dev": true,
             "requires": {
                 "debug": "2.6.9",
                 "depd": "~1.1.2",
@@ -5882,27 +6164,28 @@
                 "mime": {
                     "version": "1.4.1",
                     "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-                    "integrity":
-                        "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+                    "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+                    "dev": true
                 },
                 "statuses": {
                     "version": "1.4.0",
                     "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-                    "integrity":
-                        "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+                    "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+                    "dev": true
                 }
             }
         },
         "serialize-error": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-            "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
+            "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
+            "dev": true
         },
         "serve-static": {
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-            "integrity":
-                "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+            "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+            "dev": true,
             "requires": {
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
@@ -5913,13 +6196,14 @@
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
         },
         "set-value": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-            "integrity":
-                "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-extendable": "^0.1.1",
@@ -5931,6 +6215,7 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -5940,18 +6225,20 @@
         "setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "dev": true
         },
         "setprototypeof": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-            "integrity":
-                "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+            "dev": true
         },
         "shebang-command": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
             "requires": {
                 "shebang-regex": "^1.0.0"
             }
@@ -5959,12 +6246,14 @@
         "shebang-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
         },
         "shell-quote": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
             "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+            "dev": true,
             "requires": {
                 "array-filter": "~0.0.0",
                 "array-map": "~0.0.0",
@@ -5975,18 +6264,20 @@
         "shellwords": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-            "integrity":
-                "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+            "dev": true
         },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
         },
         "simple-plist": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-0.2.1.tgz",
             "integrity": "sha1-cXZts1IyaSjPOoByQrp2IyJjZyM=",
+            "dev": true,
             "requires": {
                 "bplist-creator": "0.0.7",
                 "bplist-parser": "0.1.1",
@@ -5996,12 +6287,14 @@
                 "base64-js": {
                     "version": "1.1.2",
                     "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz",
-                    "integrity": "sha1-1kAMrBxMZgl22Q0HoENR2JOV9eg="
+                    "integrity": "sha1-1kAMrBxMZgl22Q0HoENR2JOV9eg=",
+                    "dev": true
                 },
                 "plist": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz",
                     "integrity": "sha1-CjLKlIGxw2TpLhjcVch23p0B2os=",
+                    "dev": true,
                     "requires": {
                         "base64-js": "1.1.2",
                         "xmlbuilder": "8.2.2",
@@ -6011,25 +6304,28 @@
                 "xmlbuilder": {
                     "version": "8.2.2",
                     "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
-                    "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
+                    "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+                    "dev": true
                 }
             }
         },
         "slash": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+            "dev": true
         },
         "slide": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-            "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+            "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+            "dev": true
         },
         "snapdragon": {
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-            "integrity":
-                "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "dev": true,
             "requires": {
                 "base": "^0.11.1",
                 "debug": "^2.2.0",
@@ -6045,6 +6341,7 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -6053,6 +6350,7 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -6062,8 +6360,8 @@
         "snapdragon-node": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-            "integrity":
-                "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "dev": true,
             "requires": {
                 "define-property": "^1.0.0",
                 "isobject": "^3.0.0",
@@ -6074,6 +6372,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -6081,8 +6380,8 @@
                 "is-accessor-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -6090,8 +6389,8 @@
                 "is-data-descriptor": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -6099,8 +6398,8 @@
                 "is-descriptor": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity":
-                        "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -6110,21 +6409,22 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 },
                 "kind-of": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity":
-                        "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
                 }
             }
         },
         "snapdragon-util": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-            "integrity":
-                "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "dev": true,
             "requires": {
                 "kind-of": "^3.2.0"
             },
@@ -6133,6 +6433,7 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -6142,13 +6443,14 @@
         "source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true
         },
         "source-map-resolve": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-            "integrity":
-                "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+            "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+            "dev": true,
             "requires": {
                 "atob": "^2.1.1",
                 "decode-uri-component": "^0.2.0",
@@ -6160,8 +6462,8 @@
         "source-map-support": {
             "version": "0.4.18",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-            "integrity":
-                "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+            "dev": true,
             "requires": {
                 "source-map": "^0.5.6"
             }
@@ -6169,13 +6471,14 @@
         "source-map-url": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+            "dev": true
         },
         "spdx-correct": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.1.tgz",
-            "integrity":
-                "sha512-hxSPZbRZvSDuOvADntOElzJpenIR7wXJkuoUcUtS0erbgt2fgeaoPIYretfKpslMhfFDY4k0MZ2F5CUzhBsSvQ==",
+            "integrity": "sha512-hxSPZbRZvSDuOvADntOElzJpenIR7wXJkuoUcUtS0erbgt2fgeaoPIYretfKpslMhfFDY4k0MZ2F5CUzhBsSvQ==",
+            "dev": true,
             "requires": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
@@ -6184,14 +6487,14 @@
         "spdx-exceptions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-            "integrity":
-                "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+            "dev": true
         },
         "spdx-expression-parse": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-            "integrity":
-                "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "dev": true,
             "requires": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
@@ -6200,14 +6503,14 @@
         "spdx-license-ids": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
-            "integrity":
-                "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w=="
+            "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
+            "dev": true
         },
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-            "integrity":
-                "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.0"
             },
@@ -6216,6 +6519,7 @@
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
                     "requires": {
                         "assign-symbols": "^1.0.0",
                         "is-extendable": "^1.0.1"
@@ -6224,8 +6528,8 @@
                 "is-extendable": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                    "integrity":
-                        "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -6235,17 +6539,20 @@
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
         },
         "stacktrace-parser": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.4.tgz",
-            "integrity": "sha1-ATl5IuX2Ls8whFUiyVxP4dJefU4="
+            "integrity": "sha1-ATl5IuX2Ls8whFUiyVxP4dJefU4=",
+            "dev": true
         },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "dev": true,
             "requires": {
                 "define-property": "^0.2.5",
                 "object-copy": "^0.1.0"
@@ -6255,6 +6562,7 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -6264,18 +6572,20 @@
         "statuses": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-            "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+            "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+            "dev": true
         },
         "stream-buffers": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
-            "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
+            "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
+            "dev": true
         },
         "string-width": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-            "integrity":
-                "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
             "requires": {
                 "is-fullwidth-code-point": "^2.0.0",
                 "strip-ansi": "^4.0.0"
@@ -6284,12 +6594,14 @@
                 "ansi-regex": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
                 },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^3.0.0"
                     }
@@ -6299,8 +6611,8 @@
         "string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity":
-                "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.0"
             }
@@ -6309,6 +6621,7 @@
             "version": "3.0.1",
             "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
             }
@@ -6316,22 +6629,26 @@
         "strip-bom": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true
         },
         "strip-eof": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
         },
         "supports-color": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
         },
         "temp": {
             "version": "0.8.3",
             "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
             "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+            "dev": true,
             "requires": {
                 "os-tmpdir": "^1.0.0",
                 "rimraf": "~2.2.6"
@@ -6340,24 +6657,28 @@
                 "rimraf": {
                     "version": "2.2.8",
                     "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-                    "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+                    "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+                    "dev": true
                 }
             }
         },
         "throat": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-            "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
+            "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+            "dev": true
         },
         "through": {
             "version": "2.3.8",
             "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
         },
         "through2": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "dev": true,
             "requires": {
                 "readable-stream": "^2.1.5",
                 "xtend": "~4.0.1"
@@ -6366,13 +6687,14 @@
         "time-stamp": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+            "dev": true
         },
         "tmp": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity":
-                "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
             "requires": {
                 "os-tmpdir": "~1.0.2"
             }
@@ -6380,17 +6702,20 @@
         "tmpl": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "dev": true
         },
         "to-fast-properties": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+            "dev": true
         },
         "to-object-path": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -6399,6 +6724,7 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -6408,8 +6734,8 @@
         "to-regex": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-            "integrity":
-                "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "dev": true,
             "requires": {
                 "define-property": "^2.0.2",
                 "extend-shallow": "^3.0.2",
@@ -6421,6 +6747,7 @@
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
                     "requires": {
                         "assign-symbols": "^1.0.0",
                         "is-extendable": "^1.0.1"
@@ -6429,8 +6756,8 @@
                 "is-extendable": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                    "integrity":
-                        "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -6441,6 +6768,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "dev": true,
             "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
@@ -6450,6 +6778,7 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^3.0.2"
                     }
@@ -6458,6 +6787,7 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -6467,24 +6797,26 @@
         "trim-right": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+            "dev": true
         },
         "typedarray": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
         },
         "ua-parser-js": {
             "version": "0.7.18",
             "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-            "integrity":
-                "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+            "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==",
+            "dev": true
         },
         "uglify-es": {
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-            "integrity":
-                "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+            "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+            "dev": true,
             "requires": {
                 "commander": "~2.13.0",
                 "source-map": "~0.6.1"
@@ -6493,35 +6825,34 @@
                 "commander": {
                     "version": "2.13.0",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-                    "integrity":
-                        "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+                    "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+                    "dev": true
                 },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity":
-                        "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
                 }
             }
         },
         "ultron": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-            "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+            "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
+            "dev": true
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "1.0.4",
-            "resolved":
-                "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-            "integrity":
-                "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
+            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+            "dev": true
         },
         "unicode-match-property-ecmascript": {
             "version": "1.0.4",
-            "resolved":
-                "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
-            "integrity":
-                "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+            "dev": true,
             "requires": {
                 "unicode-canonical-property-names-ecmascript": "^1.0.4",
                 "unicode-property-aliases-ecmascript": "^1.0.4"
@@ -6529,22 +6860,21 @@
         },
         "unicode-match-property-value-ecmascript": {
             "version": "1.0.2",
-            "resolved":
-                "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
-            "integrity":
-                "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ=="
+            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+            "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+            "dev": true
         },
         "unicode-property-aliases-ecmascript": {
             "version": "1.0.4",
-            "resolved":
-                "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
-            "integrity":
-                "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
+            "dev": true
         },
         "union-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "get-value": "^2.0.6",
@@ -6555,12 +6885,14 @@
                 "arr-union": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-                    "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+                    "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+                    "dev": true
                 },
                 "extend-shallow": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -6569,6 +6901,7 @@
                     "version": "0.4.3",
                     "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+                    "dev": true,
                     "requires": {
                         "extend-shallow": "^2.0.1",
                         "is-extendable": "^0.1.1",
@@ -6581,12 +6914,14 @@
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true
         },
         "unset-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "dev": true,
             "requires": {
                 "has-value": "^0.3.1",
                 "isobject": "^3.0.0"
@@ -6596,6 +6931,7 @@
                     "version": "0.3.1",
                     "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "dev": true,
                     "requires": {
                         "get-value": "^2.0.3",
                         "has-values": "^0.1.4",
@@ -6606,6 +6942,7 @@
                             "version": "2.1.0",
                             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "dev": true,
                             "requires": {
                                 "isarray": "1.0.0"
                             }
@@ -6615,47 +6952,52 @@
                 "has-values": {
                     "version": "0.1.4",
                     "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+                    "dev": true
                 },
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
             }
         },
         "urix": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+            "dev": true
         },
         "use": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-            "integrity":
-                "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+            "dev": true
         },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
         },
         "utils-merge": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+            "dev": true
         },
         "uuid": {
             "version": "3.0.1",
             "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-            "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+            "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+            "dev": true
         },
         "validate-npm-package-license": {
             "version": "3.0.4",
-            "resolved":
-                "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-            "integrity":
-                "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
             "requires": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
@@ -6664,12 +7006,14 @@
         "vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+            "dev": true
         },
         "walker": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
             "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+            "dev": true,
             "requires": {
                 "makeerror": "1.0.x"
             }
@@ -6678,6 +7022,7 @@
             "version": "0.18.0",
             "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
             "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+            "dev": true,
             "requires": {
                 "exec-sh": "^0.2.0",
                 "minimist": "^1.2.0"
@@ -6686,14 +7031,14 @@
         "whatwg-fetch": {
             "version": "2.0.4",
             "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-            "integrity":
-                "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+            "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+            "dev": true
         },
         "which": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-            "integrity":
-                "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
@@ -6701,17 +7046,20 @@
         "which-module": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
         },
         "wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "dev": true
         },
         "wrap-ansi": {
             "version": "2.1.0",
             "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
             "requires": {
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1"
@@ -6719,9 +7067,9 @@
             "dependencies": {
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -6730,6 +7078,7 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -6741,12 +7090,14 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "write-file-atomic": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
             "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.11",
                 "imurmurhash": "^0.1.4",
@@ -6756,8 +7107,8 @@
         "ws": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-            "integrity":
-                "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+            "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+            "dev": true,
             "requires": {
                 "options": ">=0.0.5",
                 "ultron": "1.0.x"
@@ -6767,6 +7118,7 @@
             "version": "0.9.3",
             "resolved": "https://registry.npmjs.org/xcode/-/xcode-0.9.3.tgz",
             "integrity": "sha1-kQqJwWrubMC0LKgFptC0z4chHPM=",
+            "dev": true,
             "requires": {
                 "pegjs": "^0.10.0",
                 "simple-plist": "^0.2.1",
@@ -6776,12 +7128,14 @@
         "xmlbuilder": {
             "version": "9.0.7",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "dev": true
         },
         "xmldoc": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-0.4.0.tgz",
             "integrity": "sha1-0lciS+g5PqrL+DfvIn/Y7CWzaIg=",
+            "dev": true,
             "requires": {
                 "sax": "~1.1.1"
             }
@@ -6789,32 +7143,38 @@
         "xmldom": {
             "version": "0.1.27",
             "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-            "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+            "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+            "dev": true
         },
         "xpipe": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/xpipe/-/xpipe-1.0.5.tgz",
-            "integrity": "sha1-jdi/Rfw/f1Xw4FS4ePQ6YmFNr98="
+            "integrity": "sha1-jdi/Rfw/f1Xw4FS4ePQ6YmFNr98=",
+            "dev": true
         },
         "xtend": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "dev": true
         },
         "y18n": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+            "dev": true
         },
         "yallist": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "dev": true
         },
         "yargs": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
             "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+            "dev": true,
             "requires": {
                 "camelcase": "^4.1.0",
                 "cliui": "^3.2.0",
@@ -6835,6 +7195,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
             "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+            "dev": true,
             "requires": {
                 "camelcase": "^4.1.0"
             }

--- a/packages/types.ts
+++ b/packages/types.ts
@@ -284,8 +284,6 @@ export interface Provider {
     readonly setSettings: <S>(settings?: Readonly<Partial<S>>) => void
 }
 
-export type CreateProvider = (settings?: Partial<object>) => Provider
-
 /** Attach to tangle */
 export type AttachToTangle = (
     trunkTransaction: Hash,

--- a/packages/unit-converter/package-lock.json
+++ b/packages/unit-converter/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@iota/unit-converter",
-    "version": "1.0.0-beta.5",
+    "version": "1.0.0-beta.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
# Description

- Fixes return type of `composeAPI`
- Removes `CreateProvider` type 
- `composeAPI` now accepts `Settings` object only
- Adds `network: Provider` field to `Settings` object
- Allow overriding `network` with `overrideNetwork(network: Provider)`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] CI must pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes