### PR TITLE
fix: type error

### DIFF
--- a/packages/core/src/createPrepareTransfers.ts
+++ b/packages/core/src/createPrepareTransfers.ts
@@ -151,6 +151,10 @@ export const createPrepareTransfers = (provider?: Provider, now: () => number = 
             }
         }
 
+        if (!(transfers instanceof Array)) {
+            throw new Error('Invalid transfers array')
+        }
+
         const props = Promise.resolve(
             validatePrepareTransfers({
                 transactions: [],

--- a/packages/core/test/integration/prepareTransfers.test.ts
+++ b/packages/core/test/integration/prepareTransfers.test.ts
@@ -101,3 +101,16 @@ test.cb('prepareTransfers() passes correct arguments to callback', t => {
         t.end()
     })
 })
+
+test('prepareTransfers() throws intuitive error when provided invalid transfers array', async t => {
+    const invalidTransfers = {
+        address: addChecksum('A'.repeat(81)),
+        value: 3,
+    } as any
+
+    t.is(
+        t.throws(() => prepareTransfers('SEED', invalidTransfers)).message,
+        'Invalid transfers array',
+        'prepareTransfers() should throw intuitive error when provided invalid transfers array'
+    )
+})


### PR DESCRIPTION
# Description

- Checked if transfers argument is of type Array, throw an error with intuitive message 'Invalid transfers array' instead of a type error.

Fixes #308 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added a new test in prepareTransfers.test.ts

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes