### PR TITLE
Add (optional) tips param to getBalances api

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -182,23 +182,35 @@ api.prototype.findTransactions = function(searchValues, callback) {
 *   @method getBalances
 *   @param {array} addresses
 *   @param {int} threshold
+*   @param {array} [tips]
 *   @returns {function} callback
 *   @returns {object} success
 **/
-api.prototype.getBalances = function(addresses, threshold, callback) {
+api.prototype.getBalances = function(addresses, threshold, tips, callback) {
+    var missingTips = arguments.length === 3 && Object.prototype.toString.call(tips) === "[object Function]";
+    var actualCallback;
+    var actualTips;
 
-    // Check if correct transaction hashes
-    if (!inputValidator.isArrayOfHashes(addresses)) {
+    // Check if tips are provided
+    if (missingTips) {
+        actualCallback = tips;
+        actualTips = [];
+    } else {
+        actualCallback = callback;
+        actualTips = tips;
+    }
 
-        return callback(errors.invalidTrytes());
+    // Check if correct transaction hashes and tips
+    if (!inputValidator.isArrayOfHashes(addresses) || !inputValidator.isArrayOfHashes(actualTips)) {
+        return actualCallback(errors.invalidTrytes());
     }
 
     var command = apiCommands.getBalances(addresses.map(function(address) {
 
       return Utils.noChecksum(address)
-    }), threshold);
+    }), threshold, actualTips);
 
-    return this.sendCommand(command, callback)
+    return this.sendCommand(command, actualCallback)
 }
 
 /**

--- a/lib/api/apiCommands.js
+++ b/lib/api/apiCommands.js
@@ -47,14 +47,21 @@ var findTransactions = function(searchValues) {
 *   @method getBalances
 *   @param {array} addresses
 *   @param {int} threshold
+*   @param {array} [tips]
 *   @returns {object} command
 **/
-var getBalances = function(addresses, threshold) {
+var getBalances = function(addresses, threshold, tips) {
 
     var command = {
         'command'    : 'getBalances',
         'addresses'  : addresses,
         'threshold'  : threshold
+    }
+
+    // If provided tips is an array and has length
+    // Then assign tips prop to command object
+    if (Array.isArray(tips) && tips.length) {
+        command.tips = tips;
     }
 
     return command;

--- a/test/api/api.getBalances.js
+++ b/test/api/api.getBalances.js
@@ -1,0 +1,66 @@
+var chai = require('chai');
+var assert = chai.assert;
+var API = require('../../lib/api/api');
+
+describe('api.getBalances', function () {
+    var api = new API();
+
+    beforeEach(function () {
+        API.prototype.sendCommand = function (command, callback) {
+            return callback(null, command);
+        }
+    });
+
+    describe('when called with four arguments', function () {
+        describe('when invalid tips are provided', function () {
+            it('should throw an error with message "Invalid Trytes provided"', function () {
+                api.getBalances(['U'.repeat(81)], 100, ['0'], function (err) {
+                    assert.equal(err.message, 'Invalid Trytes provided');
+                });
+            });
+        });
+
+        describe('when empty tips are provided', function () {
+            it('should call "sendCommand" with an object not containing "tips" prop', function () {
+                api.getBalances(['U'.repeat(81)], 100, [], function (err, command) {
+                    var expectedCommand = {
+                        command: 'getBalances',
+                        addresses: ['U'.repeat(81)],
+                        threshold: 100
+                    };
+
+                    assert.deepEqual(command, expectedCommand);
+                });
+            });
+        });
+
+        describe('when valid tips are provided', function () {
+            it('should call "sendCommand" with an object containing "tips" prop', function () {
+                api.getBalances(['U'.repeat(81)], 100, ['9'.repeat(81)], function (err, command) {
+                    var expectedCommand = {
+                        command: 'getBalances',
+                        addresses: ['U'.repeat(81)],
+                        threshold: 100,
+                        tips: ['9'.repeat(81)]
+                    };
+
+                    assert.deepEqual(command, expectedCommand);
+                });
+            });
+        });
+    });
+
+    describe('when called with three arguments', function () {
+        it('should call "sendCommand" with an object not containing "tips" prop', function () {
+            api.getBalances(['U'.repeat(81)], 100, function (err, command) {
+                var expectedCommand = {
+                    command: 'getBalances',
+                    addresses: ['U'.repeat(81)],
+                    threshold: 100
+                };
+
+                assert.deepEqual(command, expectedCommand);
+            });
+        });
+    });
+});

--- a/test/api/apiCommands.js
+++ b/test/api/apiCommands.js
@@ -1,0 +1,77 @@
+var chai = require('chai');
+var assert = chai.assert;
+var apiCommands = require('../../lib/api/apiCommands');
+
+describe('api commands', function() {
+    describe('#getBalances', () => {
+        describe('when tips are not provided', function () {
+            it('should return an object with props "command", "addresses" and "threshold"', function() {
+                var command = apiCommands.getBalances(['U'.repeat(81)], 100);
+                var expectedCommand = {
+                    command: 'getBalances',
+                    addresses: ['U'.repeat(81)],
+                    threshold: 100
+                };
+
+                assert.deepEqual(command, expectedCommand);
+            });
+        });
+
+        describe('when tips are provided', function () {
+            describe('when provided tips is not an array', function () {
+                it('should not include "tips" prop in returned object', function() {
+                    var invalidTips = [
+                        'foo',
+                        0,
+                        undefined,
+                        {}
+                    ];
+
+                    var expectedCommand = {
+                        command: 'getBalances',
+                        addresses: ['U'.repeat(81)],
+                        threshold: 100
+                    };
+
+                    invalidTips.forEach(function (param) {
+                        var command = apiCommands.getBalances(['U'.repeat(81)], 100, param);
+
+                        assert.deepEqual(command, expectedCommand);
+                    });
+                });
+
+            });
+
+            describe('when provided tips is an array', function () {
+                describe('when is empty', function () {
+                    it('should not include "tips" prop in returned object', function() {
+                        var expectedCommand = {
+                            command: 'getBalances',
+                            addresses: ['U'.repeat(81)],
+                            threshold: 100
+                        };
+
+                        var command = apiCommands.getBalances(['U'.repeat(81)], 100, []);
+
+                        assert.deepEqual(command, expectedCommand);
+                    });
+                });
+
+                describe('when is not empty', function () {
+                    it('should include "tips" prop in returned object', function () {
+                        var expectedCommand = {
+                            command: 'getBalances',
+                            addresses: ['U'.repeat(81)],
+                            threshold: 100,
+                            tips: ['9'.repeat(81)]
+                        };
+
+                        var command = apiCommands.getBalances(['U'.repeat(81)], 100, ['9'.repeat(81)]);
+
+                        assert.deepEqual(command, expectedCommand);
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
# Description

IRI [getBalances](https://iota.readme.io/reference#getbalances) endpoint accepts an optional "tips" parameter. The library does not provide support for users for passing in tips parameter. This commit updates getBalances endpoint to accept "tips" as an optional parameter.

Fixes https://github.com/iotaledger/iota.js/issues/313

## Type of change

- [x] Enhancement

# How Has This Been Tested?

- Added unit test coverage
- Manually tested with 

```
const IOTA = require('iota.lib.js');

const iota = new IOTA({ provider: 'https://nodes.thetangle.org:443' });

const seed = 'TEST9TEST9TEST';
const options = { start: 0 };

// Test getAccountData as it uses getBalances internally
iota.api.getAccountData(seed, options, console.info);
// Test getInputs as it uses getBalances internally
iota.api.getInputs(seed, options, console.info);
// Test prepareTransfers as it uses getBalances internally
iota.api.prepareTransfers(
    seed,
    [{ address: 'U'.repeat(81), value: 100, }],
    {
        inputs: [{
            address: 'A'.repeat(81),
            balance: 100,
            keyIndex: 10,
            security: 2
        }]
    },
    console.info
);

// Test getBalances directly
const addresses = ['U'.repeat(81), 'A'.repeat(81)];

iota.api.getBalances(addresses, 100, console.info);
iota.api.getBalances(addresses, 100, ['9'.repeat(81)], console.info);
iota.api.getBalances(addresses, 100, ['foo'], console.info);
```


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes