### PR TITLE
More accurate security level validation, add validation to generateAddress

### DIFF
--- a/packages/core/src/generateAddress.ts
+++ b/packages/core/src/generateAddress.ts
@@ -1,6 +1,7 @@
 import { addChecksum } from '@iota/checksum'
 import { trits, trytes } from '@iota/converter'
 import { address, digests, key, subseed } from '@iota/signing'
+import { securityLevelValidator, seedValidator, validate } from '../../guards'
 import { Hash } from '../../types'
 
 /**
@@ -21,6 +22,8 @@ export const generateAddress = (seed: string, index: number, security: number = 
     while (seed.length % 81 !== 0) {
         seed += 9
     }
+
+    validate(seedValidator(seed), securityLevelValidator(security))
 
     const keyTrits = key(subseed(trits(seed), index), security)
     const digestsTrits = digests(keyTrits)

--- a/packages/guards.ts
+++ b/packages/guards.ts
@@ -66,8 +66,9 @@ export const isNinesTrytes = isEmpty
 export const isHash = (hash: any): hash is Hash =>
     isTrytesOfExactLength(hash, HASH_TRYTE_SIZE) || isTrytesOfExactLength(hash, HASH_TRYTE_SIZE + 9) // address w/ checksum is valid hash
 
-/* Check if security level is positive integer */
-export const isSecurityLevel = (security: any): security is number => Number.isInteger(security) && security > 0
+/* Check if security level is valid positive integer */
+export const isSecurityLevel = (security: any): security is number =>
+    Number.isInteger(security) && security > 0 && security < 4
 
 /**
  * Checks if input is valid input object. Address can be passed with or without checksum.

--- a/packages/validators/test/isSecurityLevel.test.ts
+++ b/packages/validators/test/isSecurityLevel.test.ts
@@ -8,5 +8,7 @@ test('isSecurityLevel() returns true for valid security level.', t => {
 test('isSecurityLevel() returns false for invalid security level.', t => {
     t.is(isSecurityLevel(-1), false, 'isTransactionHash() should return false for negative security level.')
 
-    t.is(isSecurityLevel(0), false, 'isSecurityLevel() should return fasle for security level of 0.')
+    t.is(isSecurityLevel(0), false, 'isSecurityLevel() should return false for security level of 0.')
+
+    t.is(isSecurityLevel(4), false, 'isSecurityLevel() should return false for security level above 3.')
 })


### PR DESCRIPTION
# Description

- Security level validation should be more accurate by throwing error on levels above ``3``.
- Seed and security level in ``generateAddress()`` should be validated.

Related to #325 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x]  Manually tested ``generateAddress()``
- [x]  Updated [unit test](https://github.com/iotaledger/iota.js/compare/next...cym00n:fix/securityLevelValidation?expand=1#diff-112d8d581d52c09ceffba45ce7b112b1) for ``isSecurityLevel()``


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes