### PR TITLE
fix: disable prettier formatting of markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
                 "tslint --fix",
                 "git add"
             ],
-            "*.{js,ts,json,md}": [
+            "*.{js,ts,json}": [
                 "prettier --write",
                 "git add"
             ]


### PR DESCRIPTION
# Description

Disable prettier formatting of staged markdown files on precommit.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested precommit hook locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes