### PR TITLE
refactor(checksum): remove array support

### DIFF
--- a/packages/checksum/README.md
+++ b/packages/checksum/README.md
@@ -17,7 +17,31 @@ yarn add @iota/checksum
 
 ## API Reference
 
-    <a name="module_checksum..isValidChecksum"></a>
+    <a name="module_checksum..addChecksum"></a>
+
+### *checksum*~addChecksum(input, [checksumLength], [isAddress])
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| input | <code>string</code> |  | Input trytes |
+| [checksumLength] | <code>number</code> | <code>9</code> | Checksum trytes length |
+| [isAddress] | <code>boolean</code> | <code>true</code> | Flag to denote if given input is address. Defaults to `true`. |
+
+Generates and appends the 9-tryte checksum of the given trytes, usually an address.
+
+**Returns**: <code>string</code> - Address (with checksum)  
+<a name="module_checksum..removeChecksum"></a>
+
+### *checksum*~removeChecksum(input)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| input | <code>string</code> | Input trytes |
+
+Removes the 9-trytes checksum of the given input.
+
+**Returns**: <code>string</code> - Trytes without checksum  
+<a name="module_checksum..isValidChecksum"></a>
 
 ### *checksum*~isValidChecksum(addressWithChecksum)
 

--- a/packages/checksum/test/checksum.test.ts
+++ b/packages/checksum/test/checksum.test.ts
@@ -1,27 +1,17 @@
-import { addresses, addressesWithChecksum, addressWithChecksum, addressWithInvalidChecksum } from '@iota/samples'
+import { address, addressWithChecksum, addressWithInvalidChecksum } from '@iota/samples'
 import test from 'ava'
 import { addChecksum, errors, isValidChecksum, removeChecksum } from '../src'
 
 const invalidAddress = 'UYEEERFQYTPFAHIPXDQAQYWYMSMCLMGBTYAXLWFRFFWPYFOICOVLK9A9VYNCKK9TQUNBTARCEQXJHD'
 
 test('addChecksum() adds 9-trytes checksum', t => {
-    t.is(
-        addChecksum(addresses[0]),
-        addressesWithChecksum[0],
-        'addChecksum() should add 9-trytes checksum to the end of address.'
-    )
-
-    t.deepEqual(
-        addChecksum(addresses.slice(0, 1)),
-        addressesWithChecksum.slice(0, 1),
-        'addChecksum() should add 9-trytes checksum to the end of each address in a given array.'
-    )
+    t.is(addChecksum(address), addressWithChecksum, 'addChecksum() should add 9-trytes checksum to the end of address.')
 })
 
 test('addChecksum() returns the exact address, if was passed with checksum', t => {
     t.is(
-        addChecksum(addressesWithChecksum[0]),
-        addressesWithChecksum[0],
+        addChecksum(addressWithChecksum),
+        addressWithChecksum,
         'addChecksum() should return the exact address, if was passed with checksum.'
     )
 })
@@ -34,14 +24,6 @@ test('addChecksum() throws error for invalid addresses', t => {
     )
 
     t.is(error.message, errors.INVALID_ADDRESS, 'addChecksum() should throw correct error message.')
-})
-
-test('addChecksum() does not mutate the original array', t => {
-    const arr = [...addresses.slice(0, 1).map(a => a.slice(0, 81))]
-
-    addChecksum(arr)
-
-    t.deepEqual(arr, addresses.slice(0, 1), 'addChecksum() should not mutate the original array.')
 })
 
 test('addChecksum() adds checksum of arbitrary length', t => {
@@ -58,7 +40,7 @@ test('isValidChecksum() correctly validates the checksum', t => {
         'isValidChecksum() should return false for address with invalid checksum.'
     )
 
-    t.is(isValidChecksum(addresses[0]), false, 'isValidChecksum() should return false for address without checksum.')
+    t.is(isValidChecksum(address), false, 'isValidChecksum() should return false for address without checksum.')
 })
 
 test('isValidChecksum() throws error for invalid address', t => {
@@ -73,32 +55,18 @@ test('isValidChecksum() throws error for invalid address', t => {
 
 test('removeChecksum() removes checksum from addresses with checksum', t => {
     t.deepEqual(
-        removeChecksum(addressesWithChecksum.slice(0, 1)),
-        addresses.slice(0, 1),
+        removeChecksum(addressWithChecksum),
+        address,
         'removeChecksum() should remove checksum from address with checksum.'
-    )
-
-    t.deepEqual(
-        removeChecksum(addressesWithChecksum.slice(0, 1)),
-        addresses.slice(0, 1),
-        'removeChecksum() should remove checksum from each address with checksum in given array.'
     )
 })
 
 test('removeChecksum() returns the exact address, if was passed without checksum', t => {
     t.deepEqual(
-        removeChecksum(addresses),
-        addresses,
+        removeChecksum(address),
+        address,
         'removeChecksum() should return the exact address if was passed without checksum.'
     )
-})
-
-test('removeChecksum() does not mutate the original array', t => {
-    const arr = [addressWithChecksum]
-
-    removeChecksum(arr)
-
-    t.deepEqual(arr, [addressWithChecksum], 'removeChecksum() should not mutate the original array.')
 })
 
 test('removeChecksum() throws error for invalid addresses', t => {

--- a/packages/core/src/createFindTransactions.ts
+++ b/packages/core/src/createFindTransactions.ts
@@ -43,7 +43,7 @@ export const removeAddressChecksum = (query: FindTransactionsQuery) =>
     query.addresses
         ? {
               ...query,
-              addresses: removeChecksum(query.addresses),
+              addresses: query.addresses.map(removeChecksum),
           }
         : query
 

--- a/packages/core/src/createGetBalances.ts
+++ b/packages/core/src/createGetBalances.ts
@@ -72,7 +72,7 @@ export const createGetBalances = ({ send }: Provider) =>
             .then(() =>
                 send<GetBalancesCommand, GetBalancesResponse>({
                     command: IRICommand.GET_BALANCES,
-                    addresses: removeChecksum(addresses), // Addresses passed to IRI should not have the checksum
+                    addresses: addresses.map(removeChecksum), // Addresses passed to IRI should not have the checksum
                     threshold,
                     ...(Array.isArray(tips) && tips.length && { tips }),
                 })

--- a/packages/core/src/createGetNewAddress.ts
+++ b/packages/core/src/createGetNewAddress.ts
@@ -88,7 +88,11 @@ export const generateAddresses = (seed: Trytes, index: number, security: number,
         .map(() => generateAddress(seed, index++, security))
 
 export const applyChecksumOption = (checksum: boolean) => (addresses: Trytes | ReadonlyArray<Trytes>) =>
-    checksum ? (Array.isArray(addresses) ? addChecksum(addresses) : addChecksum(asArray(addresses))[0]) : addresses
+    checksum
+        ? Array.isArray(addresses)
+            ? addresses.map(addr => addChecksum(addr))
+            : addChecksum(addresses as Trytes)
+        : addresses
 
 export const applyReturnAllOption = (returnAll: boolean, total?: number) => (addresses: ReadonlyArray<Trytes>) =>
     returnAll || total ? addresses : addresses[addresses.length - 1]

--- a/packages/core/src/createIsReattachable.ts
+++ b/packages/core/src/createIsReattachable.ts
@@ -43,7 +43,7 @@ export const createIsReattachable = (provider: Provider) => {
                 // 1. Remove checksum and validate addresses
                 validate(arrayValidator(trytesValidator)(inputAddressArray, INVALID_ADDRESS))
 
-                addresses = inputAddressArray.map(addr => removeChecksum(addr))
+                addresses = inputAddressArray.map(removeChecksum)
 
                 validate(arrayValidator(hashValidator)(addresses))
             })

--- a/packages/core/src/createWereAddressesSpentFrom.ts
+++ b/packages/core/src/createWereAddressesSpentFrom.ts
@@ -30,7 +30,7 @@ export const createWereAddressesSpentFrom = ({ send }: Provider, caller?: string
         .then(() =>
             send<WereAddressesSpentFromCommand, WereAddressesSpentFromResponse>({
                 command: IRICommand.WERE_ADDRESSES_SPENT_FROM,
-                addresses: removeChecksum(addresses),
+                addresses: addresses.map(removeChecksum),
             })
         )
         .then(res => res.states)


### PR DESCRIPTION
# Description

My initial issue was with `removeChecksum`: it throws `INVALID_ADDRESS` when it receives an empty array as input.
After discussing with Chris I removed the array support (polymorphism) of `addChecksum` and `removeChecksum`.
That makes the code and the doc simpler while the array support is easily accessible with `addresses.map(removeChecksum)`


## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
It depends if `add/removeChecksum` were used with arrays.

# How Has This Been Tested?

- [x] `checksum` package tests adjusted
- [x] all tests passed


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
