### PR TITLE
Terminate execution of isPromotable api method once promise is rejected

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -2014,6 +2014,7 @@ api.prototype.isPromotable = function(tail, options) {
         self.sendCommand(command, function(err, res) {
             if (err) {
               reject(err)
+              return;
             }
             if (!res.state && options.rejectWithReason) {
               reject(new Error('Transaction is inconsistent. Reason: ' + res.info))


### PR DESCRIPTION
# Description

[isPromotable](https://github.com/iotaledger/iota.js/blob/d1d3aa57f7bb3879bc073cc4e59c9b5e4b83deda/lib/api/api.js#L1989) doesn't terminate the execution of function once the promise is rejected.

```
const IOTA = require('iota.lib.js');

const iota = new IOTA({ provider: 'http://localhost:14265' });

iota.api.setApiTimeout(5000);

iota.api.isPromotable('9'.repeat(81)).catch(console.error); // TypeError: Cannot read property 'state' of null

```

Related issue - https://github.com/iotaledger/trinity-wallet/issues/712
## Type of change

- [x] Bug fix 

# How Has This Been Tested?

- Tested using the above script by forcing promise rejection. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes