### PR TITLE
fix(ci): add API level 27 to Android CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,11 @@ matrix:
       name: Android
       android:
         components:
+          - android-27
           - android-19
           - tools
           - platform-tools
-          - build-tools-26.0.1
+          - build-tools-27.0.3
           - extra-google-m2repository
           - extra-android-m2repository
       addons:
@@ -37,7 +38,7 @@ matrix:
         - sudo apt-get install ant
         - wget https://dl.google.com/android/repository/android-ndk-r17c-linux-x86_64.zip
         - sha1sum -c android-ndk.sha
-        - unzip android-ndk-r17c-linux-x86_64.zip
+        - unzip -q android-ndk-r17c-linux-x86_64.zip
         - mv android-ndk-r17c/ ${ANDROID_HOME}/ndk-bundle
       install:
         - echo y | sdkmanager "cmake;3.6.4111459"


### PR DESCRIPTION
# Description

Prevents Android CI from failing on newer versions of `iotaledger/entangled` (such as the one included in #355), which require Android API level 27.

## Type of change

- [x] CI fix


# How Has This Been Tested?

- [ ] CI passes


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes