### PR TITLE
Use correct trytes for transaction.value

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -222,7 +222,7 @@ var transactionObject = function(trytes, hash) {
 
     thisTransaction.signatureMessageFragment = trytes.slice(0, 2187);
     thisTransaction.address = trytes.slice(2187, 2268);
-    thisTransaction.value = Converter.value(transactionTrits.slice(6804, 6837));
+    thisTransaction.value = Converter.value(transactionTrits.slice(6804, 6885));
     thisTransaction.obsoleteTag = trytes.slice(2295, 2322);
     thisTransaction.timestamp = Converter.value(transactionTrits.slice(6966, 6993));
     thisTransaction.currentIndex = Converter.value(transactionTrits.slice(6993, 7020));


### PR DESCRIPTION
# Description

`value` in transaction uses 27 trytes but during trytes to transaction object only 11 trytes were being used.

This PR allocates correct (27 trytes) during trytes to transaction object conversion.

Related https://github.com/iotaledger/iota.js/pull/391

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Running existing tests and ensuring that they all pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes