### PR TITLE
fix(persistence-adapter-level): bundled version of level-js & leveldown

### DIFF
--- a/packages/persistence-adapter-level/package-lock.json
+++ b/packages/persistence-adapter-level/package-lock.json
@@ -1,42 +1,14 @@
 {
     "name": "@iota/persistence-adapter-level",
-    "version": "1.0.0-beta.17",
+    "version": "1.0.0-beta.19",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "@types/abstract-leveldown": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-5.0.1.tgz",
-            "integrity": "sha512-wYxU3kp5zItbxKmeRYCEplS2MW7DzyBnxPGj+GJVHZEUZiK/nn5Ei1sUFgURDh+X051+zsGe28iud3oHjrYWQQ=="
-        },
-        "@types/events": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-            "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
-        },
-        "@types/leveldown": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@types/leveldown/-/leveldown-4.0.0.tgz",
-            "integrity": "sha512-1+h/AaqhhQK1/Q1Nr1sHyy7JDcVmKosL9uYLb4bhdLf7MQP4f4daWRLuFQKp8n/pRbai2XPUpR7z33N85m2Hng==",
-            "requires": {
-                "@types/abstract-leveldown": "*",
-                "@types/node": "*"
-            }
-        },
-        "@types/levelup": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-3.1.0.tgz",
-            "integrity": "sha512-Y2SC5PskYsE8+dELuWLCMG+UcUrkhhIz5wV55yX73AAVqr3kDXLYlj6k/vuchXUt1L1b/P1Frt4Dcc3WmWcbLA==",
-            "requires": {
-                "@types/abstract-leveldown": "*",
-                "@types/events": "*",
-                "@types/node": "*"
-            }
-        },
         "@types/node": {
             "version": "11.12.2",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-11.12.2.tgz",
-            "integrity": "sha512-c82MtnqWB/CqqK7/zit74Ob8H1dBdV7bK+BcErwtXbe0+nUGkgzq5NTDmRW/pAv2lFtmeNmW95b0zK2hxpeklg=="
+            "integrity": "sha512-c82MtnqWB/CqqK7/zit74Ob8H1dBdV7bK+BcErwtXbe0+nUGkgzq5NTDmRW/pAv2lFtmeNmW95b0zK2hxpeklg==",
+            "dev": true
         },
         "abstract-leveldown": {
             "version": "6.0.2",
@@ -172,6 +144,17 @@
                 "domelementtype": "1"
             }
         },
+        "encoding-down": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.1.0.tgz",
+            "integrity": "sha512-pBW1mbuQDHQhQLBtqarX8x2oLynahiOzBY5L/BosNqcstJ8MjpSc3rx1yCUIqb6bUE2vsp3t0BaXS0ZDP1s5pg==",
+            "requires": {
+                "abstract-leveldown": "^6.0.0",
+                "inherits": "^2.0.3",
+                "level-codec": "^9.0.0",
+                "level-errors": "^2.0.0"
+            }
+        },
         "entities": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
@@ -295,6 +278,11 @@
                 "readable-stream": "^3.1.1"
             }
         },
+        "immediate": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+            "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
+        },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -340,11 +328,32 @@
                 "has-symbols": "^1.0.0"
             }
         },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true
+        },
+        "level": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/level/-/level-5.0.1.tgz",
+            "integrity": "sha512-wcak5OQeA4rURGacqS62R/xNHjCYnJSQDBOlm4KNUGJVE9bWv2B04TclqReYejN+oD65PzD4FsqeWoI5wNC5Lg==",
+            "requires": {
+                "level-js": "^4.0.0",
+                "level-packager": "^5.0.0",
+                "leveldown": "^5.0.0",
+                "opencollective-postinstall": "^2.0.0"
+            }
+        },
+        "level-codec": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
+            "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q=="
         },
         "level-concat-iterator": {
             "version": "2.0.1",
@@ -367,6 +376,27 @@
                 "inherits": "^2.0.1",
                 "readable-stream": "^3.0.2",
                 "xtend": "^4.0.0"
+            }
+        },
+        "level-js": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/level-js/-/level-js-4.0.1.tgz",
+            "integrity": "sha512-m5JRIyHZn5VnCCFeRegJkn5bQd3MJK5qZX12zg3Oivc8+BUIS2yFS6ANMMeHX2ieGxucNvEn6/ZnyjmZQLLUWw==",
+            "requires": {
+                "abstract-leveldown": "~6.0.1",
+                "immediate": "~3.2.3",
+                "inherits": "^2.0.3",
+                "ltgt": "^2.1.2",
+                "typedarray-to-buffer": "~3.1.5"
+            }
+        },
+        "level-packager": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.0.2.tgz",
+            "integrity": "sha512-sJWdeW5tObvTvgP4Xf2psL5CEUsZjDjiTtlcimHp3Ifd4qbmkEGquN82C5ZtC7VpWEiISeUIBtIcCskVzEpvFw==",
+            "requires": {
+                "encoding-down": "^6.0.0",
+                "levelup": "^4.0.0"
             }
         },
         "leveldown": {
@@ -405,6 +435,11 @@
             "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
+        },
+        "ltgt": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+            "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
         },
         "merge": {
             "version": "1.2.1",
@@ -472,6 +507,11 @@
             "requires": {
                 "wrappy": "1"
             }
+        },
+        "opencollective-postinstall": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+            "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
         },
         "parse5": {
             "version": "3.0.3",
@@ -628,6 +668,14 @@
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
+        },
+        "typedarray-to-buffer": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+            "requires": {
+                "is-typedarray": "^1.0.0"
+            }
         },
         "util-deprecate": {
             "version": "1.0.2",

--- a/packages/persistence-adapter-level/package.json
+++ b/packages/persistence-adapter-level/package.json
@@ -49,10 +49,7 @@
     "license": "MIT",
     "dependencies": {
         "@iota/converter": "^1.0.0-beta.19",
-        "@types/leveldown": "^4.0.0",
-        "@types/levelup": "^3.1.0",
-        "leveldown": "^5.0.0",
-        "levelup": "^4.0.1"
+        "level": "^5.0.1"
     },
     "devDependencies": {
         "@iota/transaction": "^1.0.0-beta.19",

--- a/packages/persistence-adapter-level/src/@types/level/index.d.ts
+++ b/packages/persistence-adapter-level/src/@types/level/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'level'

--- a/packages/persistence-adapter-level/src/persistenceAdapterLevel.ts
+++ b/packages/persistence-adapter-level/src/persistenceAdapterLevel.ts
@@ -1,8 +1,6 @@
 import { bytesToTrits, tritsToBytes } from '@iota/converter'
-import { AbstractLevelDOWN } from 'abstract-leveldown'
 import * as Promise from 'bluebird'
-import leveldown from 'leveldown'
-import * as levelup from 'levelup'
+import * as level from 'level'
 import * as path from 'path'
 import {
     CreatePersistenceAdapter,
@@ -25,7 +23,6 @@ export {
 export const createPersistenceAdapter = ({
     persistenceID,
     persistencePath,
-    store = leveldown,
 }: PersistenceAdapterParams): PersistenceAdapter<string, Int8Array> => {
     if (typeof persistenceID !== 'string') {
         throw new TypeError('Illegal storeID.')
@@ -35,9 +32,7 @@ export const createPersistenceAdapter = ({
         throw new TypeError('Illegal store path.')
     }
 
-    const db: levelup.LevelUp<AbstractLevelDOWN<string, Buffer>> = levelup.default(
-        store(path.join(persistencePath, persistenceID))
-    )
+    const db = level(path.join(persistencePath, persistenceID), { keyEncoding: 'utf8', valueEncoding: 'binary' })
 
     return {
         get: key => Promise.try(() => db.get(key)).then(bytesToTrits),

--- a/packages/persistence-adapter-level/test/persistenceAdapterLevel.test.ts
+++ b/packages/persistence-adapter-level/test/persistenceAdapterLevel.test.ts
@@ -1,5 +1,4 @@
 import { bytesToTrits, valueToTrits } from '@iota/converter'
-import leveldown from 'leveldown'
 import { describe, Try } from 'riteway'
 import {
     createPersistenceAdapter,
@@ -84,7 +83,7 @@ describe('adapter.put(key, value) -> adapter.read(key)', async assert => {
         given: 'a written value',
         should: 'read it',
         actual: await (async () => {
-            const adapter = isolate({ store: leveldown })
+            const adapter = isolate()
 
             await adapter.put('key', valueToTrits(999314))
 


### PR DESCRIPTION
# Description

Uses `level` package which bundles `leveldown` (node) and `level-js`(browsers).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] CI must pass