### PR TITLE
http-client can be supplied with an agent

### DIFF
--- a/packages/http-client/README.md
+++ b/packages/http-client/README.md
@@ -66,6 +66,7 @@ Sends an http request to a specified host.
 | [settings.provider] | <code>string</code> | <code>&quot;http://localhost:14265&quot;</code> | Uri of IRI node |
 | [settings.apiVersion] | <code>string</code> \| <code>number</code> | <code>1</code> | IOTA Api version to be sent as `X-IOTA-API-Version` header. |
 | [settings.requestBatchSize] | <code>number</code> | <code>1000</code> | Number of search values per request. |
+| [settings.agent] | <code>object</code> | <code>{}</code> | Agent to handle the connections |
 
 <a name="module_http-client..createHttpClient"></a>
 
@@ -77,6 +78,7 @@ Sends an http request to a specified host.
 | [settings.provider] | <code>string</code> | <code>&quot;http://localhost:14265&quot;</code> | Uri of IRI node |
 | [settings.apiVersion] | <code>string</code> \| <code>number</code> | <code>1</code> | IOTA Api version to be sent as `X-IOTA-API-Version` header. |
 | [settings.requestBatchSize] | <code>number</code> | <code>1000</code> | Number of search values per request. |
+| [settings.agent] | <code>object</code> | <code>{}</code> | Agent to handle the connections |
 
 Create an http client to access IRI http API.
 

--- a/packages/http-client/src/httpClient.ts
+++ b/packages/http-client/src/httpClient.ts
@@ -78,21 +78,21 @@ export const createHttpClient = (settings?: Partial<Settings>): Provider => {
          */
         send: <C extends BaseCommand, R>(command: Readonly<C>): Promise<Readonly<R>> =>
             Promise.try(() => {
-                const { provider, user, password, requestBatchSize, apiVersion } = currentSettings
+                const { provider, user, password, requestBatchSize, apiVersion, agent } = currentSettings
 
                 if (isBatchableCommand(command)) {
                     const keysToBatch = getKeysToBatch(command, requestBatchSize)
 
                     if (keysToBatch.length) {
                         return batchedSend<C>(
-                            { command, uri: provider, user, password, apiVersion },
+                            { command, uri: provider, user, password, apiVersion, agent },
                             keysToBatch,
                             requestBatchSize
                         )
                     }
                 }
-
-                return send<C>({ command, uri: provider, user, password, apiVersion })
+                
+                return send<C>({ command, uri: provider, user, password, apiVersion, agent })
             }),
 
         /**

--- a/packages/http-client/src/request.ts
+++ b/packages/http-client/src/request.ts
@@ -1,5 +1,7 @@
 import 'cross-fetch/polyfill' // tslint:disable-line no-submodule-imports
 import * as parseUrl from 'url-parse'
+import { Agent as HttpAgent } from 'http'
+import { Agent as HttpsAgent} from 'https'
 import {
     BaseCommand,
     FindTransactionsResponse,
@@ -21,7 +23,8 @@ export interface RequestParams<C> {
     readonly uri?: string
     readonly apiVersion?: string | number
     readonly user?: string
-    readonly password?: string
+    readonly password?: string,
+    readonly agent?:HttpAgent | HttpsAgent
 }
 
 /**
@@ -55,12 +58,12 @@ export const send = <C extends BaseCommand>(params: RequestParams<C>): Promise<R
         }
         headers.Authorization = `Basic ${Buffer.from(`${params.user}:${params.password}`).toString('base64')}`
     }
-
-    return fetch(uri, {
+    
+    return fetch(uri,Object.assign({
         method: 'POST',
         headers,
         body: JSON.stringify(params.command),
-    }).then(res =>
+    },{ agent : params.agent })).then(res =>
         res
             .json()
             .then(json =>

--- a/packages/http-client/src/settings.ts
+++ b/packages/http-client/src/settings.ts
@@ -1,5 +1,7 @@
 import * as parseUrl from 'url-parse'
 import { getOptionsWithDefaults } from '../../types'
+import { Agent as HttpAgent } from 'http'
+import { Agent as HttpsAgent } from 'https'
 export interface Settings {
     readonly provider: string
     readonly host?: string // deprecated
@@ -9,7 +11,8 @@ export interface Settings {
     readonly password?: string
     readonly token?: string
     readonly requestBatchSize: number
-    readonly apiVersion: number | string
+    readonly apiVersion: number | string,
+    readonly agent?: HttpAgent | HttpsAgent
 }
 
 export const DEFAULT_PORT = 14265
@@ -36,6 +39,7 @@ export const getSettingsWithDefaults = (settings: Partial<Settings> = {}): Setti
         token,
         requestBatchSize,
         apiVersion,
+        agent
     } = getOptionsWithDefaults(defaults)(settings)
 
     let providerUri: string = provider
@@ -65,5 +69,6 @@ export const getSettingsWithDefaults = (settings: Partial<Settings> = {}): Setti
         }
     }
 
-    return { provider: providerUri, requestBatchSize, apiVersion, user, password }
+
+    return { provider: providerUri, requestBatchSize, apiVersion, user, password, agent }
 }

--- a/packages/http-client/test/send.ts
+++ b/packages/http-client/test/send.ts
@@ -1,4 +1,6 @@
 import * as nock from 'nock'
+import { Agent as HttpAgent } from 'http';
+import { Agent as HttpsAgent } from 'https';
 import {
     FindTransactionsCommand,
     FindTransactionsResponse,
@@ -16,6 +18,8 @@ export const headers = (version: string | number = apiVersion) => ({
         'X-IOTA-API-Version': version.toString(),
     },
 })
+
+export const agents = (options: any) => Object.assign(options.host.startsWith('https') ? new HttpsAgent() : new HttpAgent(), options);
 
 export const findTransactionsCommand: FindTransactionsCommand = {
     command: IRICommand.FIND_TRANSACTIONS,


### PR DESCRIPTION
# Description

http-client can be provided  with an agent, this let us behind a proxy use the library.

Fixes #178 

## Type of change


- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Checks the fetch parameter "requestinfo" contains the supplied agent.


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes