### PR TITLE
feat(account): state getters & import/export

### DIFF
--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -13,7 +13,7 @@ import { bundle as bundleHash, isMultipleOfTransactionLength, TRANSACTION_LENGTH
 import { asTransactionObject } from '@iota/transaction-converter'
 import * as Promise from 'bluebird'
 import { EventEmitter } from 'events'
-import { Bundle, CreatePersistenceAdapter, PersistencePutCommand, Transaction, Trytes } from '../../types'
+import { Bundle, CreatePersistenceAdapter, Transaction, Trytes } from '../../types'
 import { preset as defaultPreset } from './preset'
 
 export interface AddressGenerationParams {


### PR DESCRIPTION
# Description

Adds methods to get the current account state;
`getDeposits`:  returns a list of available deposit address and their metadata
`getWithdrawals`: returns a list of withdrawals
`exportState`: returns a full state object
`importState`: imports an account from a state object.

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?
- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes