### PR TITLE
fix(account): add wereAddressesSpentFrom check

### DIFF
--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -87,6 +87,7 @@ export interface Network {
     readonly getTransactionsToApprove: API['getTransactionsToApprove']
     readonly attachToTangle: API['attachToTangle']
     readonly getBundlesFromAddresses: API['getBundlesFromAddresses']
+    readonly wereAddressesSpentFrom: API['wereAddressesSpentFrom']
 }
 export interface TransactionAttachment {
     readonly startAttaching: (params: TransactionAttachmentStartParams) => void

--- a/packages/core/src/composeAPI.ts
+++ b/packages/core/src/composeAPI.ts
@@ -25,7 +25,6 @@ import {
     createGetBundle,
     createGetInclusionStates,
     createGetInputs,
-    // createWereAddressesSpentFrom,
     createGetLatestInclusion,
     createGetNeighbors,
     createGetNewAddress,
@@ -39,13 +38,14 @@ import {
     createIsReattachable,
     createPrepareTransfers,
     createPromoteTransaction,
-    // createSendTransfer,
     createRemoveNeighbors,
+    // createSendTransfer,
     createReplayBundle,
     createSendTrytes,
     createStoreAndBroadcast,
     createStoreTransactions,
     createTraverseBundle,
+    createWereAddressesSpentFrom,
     FindTransactionsQuery, // tslint:disable-line no-unused-variable
     GetAccountDataOptions, // tslint:disable-line no-unused-variable
     GetInputsOptions, // tslint:disable-line no-unused-variable
@@ -155,7 +155,7 @@ export const composeAPI = (settings: Partial<Settings> = {}) => {
         interruptAttachingToTangle: createInterruptAttachingToTangle(provider),
         removeNeighbors: createRemoveNeighbors(provider),
         storeTransactions: createStoreTransactions(provider),
-        // wereAddressesSpentFrom: createWereAddressesSpentFrom(provider),
+        wereAddressesSpentFrom: createWereAddressesSpentFrom(provider),
         sendCommand: provider.send,
 
         // Wrapper methods

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,11 +85,11 @@ export { createStoreTransactions } from './createStoreTransactions'
 // It's being used internally by `getNewAddress()`.
 // Avoid developing programs that rely on this method.
 //
-// export {
-//     createWereAddressesSpentFrom,
-//     WereAddressesSpentFromCommand,
-//     WereAddressesSpentFromResponse
-// } from './createWereAddressesSpentFrom'
+export {
+    createWereAddressesSpentFrom,
+    WereAddressesSpentFromCommand,
+    WereAddressesSpentFromResponse,
+} from './createWereAddressesSpentFrom'
 
 // Wrappers
 export { createBroadcastBundle } from './createBroadcastBundle'


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up to smaller PRs. This will help getting it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split to several PRs!!!!!
4. It will be helpful if you make additional comments on the code via github PR review to explain the choices you made
-->

# Description

Aborts `sendToCDA()` if output address was spent from.
Uses [`wereAddressesSpentFrom`](https://docs.iota.org/docs/node-software/0.1/iri/references/api-reference#wereaddressesspentfrom) command.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] added integration test
- [x] CI must pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes