### PR TITLE
fix(account): add wereAddressesSpentFrom check in address generation

### DIFF
--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -18,9 +18,10 @@ import { preset as defaultPreset } from './preset'
 
 export interface AddressGenerationParams {
     readonly seed: Int8Array
+    readonly security: 1 | 2 | 3
     readonly persistence: Persistence<string, Int8Array>
     readonly timeSource: TimeSource
-    readonly security: 1 | 2 | 3
+    readonly network: Network
 }
 export interface TransactionIssuanceParams {
     readonly seed: Int8Array
@@ -197,6 +198,7 @@ export function createAccountWithPreset<X, Y, Z>(preset: AccountPreset<X, Y, Z>)
                     persistence,
                     timeSource,
                     security: preset.security,
+                    network,
                 }),
                 preset.transactionIssuance.call(this, {
                     seed: seed as Int8Array,

--- a/packages/account/test/account.test.ts
+++ b/packages/account/test/account.test.ts
@@ -1,10 +1,10 @@
-import { CDA } from '@iota/cda'
+import { CDATransfer } from '@iota/cda'
 import { trytesToTrits } from '@iota/converter'
 import { generateAddress } from '@iota/core'
 import * as BluebirdPromise from 'bluebird'
 import * as nock from 'nock'
-import { describe } from 'riteway'
-import { IRICommand } from '../../types'
+import { describe, Try } from 'riteway'
+import { IRICommand, Trytes } from '../../types'
 import { createAccount, createAccountWithPreset } from '../src/account'
 import { preset } from '../src/preset'
 import {
@@ -16,7 +16,8 @@ const persistencePath = './test/temp'
 const currentTime = Math.floor(Date.now() / 1000)
 const futureTime = 6833278800
 const pastTime = currentTime - 7 * 24 * 60 * 60 * 1000
-const delay = (t: number) => new Promise(resolve => setTimeout(resolve, t))
+
+const noChecksum = (address: Trytes) => address.slice(0, 81)
 
 const headers = {
     reqheaders: {
@@ -25,9 +26,129 @@ const headers = {
     },
 }
 
+const assertRemoteSpentState = (address: Trytes, state: boolean) =>
+    nock('http://localhost:14265', headers)
+        .post('/', {
+            command: IRICommand.WERE_ADDRESSES_SPENT_FROM,
+            addresses: [noChecksum(address)],
+        })
+        .times(1)
+        .reply(200, {
+            states: [state],
+        })
+
+const assertBalance = (address: Trytes, balance: number) =>
+    nock('http://localhost:14265', headers)
+        .post('/', {
+            command: IRICommand.GET_BALANCES,
+            addresses: [noChecksum(address)],
+            threshold: 100,
+        })
+        .times(1)
+        .reply(200, {
+            balances: [balance],
+            milestone: 'M'.repeat(81),
+            milestoneIndex: 1,
+        })
+
+const assertTransfer = (transfer: CDATransfer, trytes: Trytes[]) => {
+    const hash = 'ZZKVOZRYHZVYORKHDLWRNIWKWLZMVBNFSPQC99PYHVJFRYRHXVUTHPQOVPJBRNFLYWDNKBBUJOTDQVTDE'
+    const transactionsToApprove = {
+        trunkTransaction: '9'.repeat(81),
+        branchTransaction: '9'.repeat(81),
+    }
+
+    nock('http://localhost:14265', headers)
+        .post('/', {
+            command: IRICommand.FIND_TRANSACTIONS,
+            addresses: [noChecksum(transfer.address)],
+        })
+        .times(1)
+        .reply(200, {
+            hashes: [hash],
+        })
+
+    nock('http://localhost:14265', headers)
+        .post('/', {
+            command: IRICommand.GET_TRYTES,
+            hashes: [hash],
+        })
+        .times(1)
+        .reply(200, {
+            trytes: [trytes[0]],
+        })
+
+    nock('http://localhost:14265', headers)
+        .persist()
+        .post('/', { command: IRICommand.GET_NODE_INFO })
+        .reply(200, {
+            appName: 'IRI',
+            appVersion: '',
+            duration: 100,
+            jreAvailableProcessors: 4,
+            jreFreeMemory: 13020403,
+            jreMaxMemory: 1241331231,
+            jreTotalMemory: 4245234332,
+            latestMilestone: 'M'.repeat(81),
+            latestMilestoneIndex: 1,
+            latestSolidSubtangleMilestone: 'M'.repeat(81),
+            latestSolidSubtangleMilestoneIndex: 1,
+            neighbors: 5,
+            packetsQueueSize: 23,
+            time: 213213214,
+            tips: 123,
+            transactionsToRequest: 10,
+        })
+
+    nock('http://localhost:14265', headers)
+        .post('/', {
+            command: IRICommand.GET_INCLUSION_STATES,
+            transactions: [hash],
+            tips: ['M'.repeat(81)],
+        })
+        .times(1)
+        .reply(200, {
+            states: [false],
+        })
+
+    nock('http://localhost:14265', headers)
+        .post('/', {
+            command: IRICommand.CHECK_CONSISTENCY,
+            tails: [hash],
+        })
+        .times(1)
+        .reply(200, {
+            states: [false],
+        })
+
+    nock('http://localhost:14265', headers)
+        .post('/', {
+            command: IRICommand.GET_TRANSACTIONS_TO_APPROVE,
+            depth: 3,
+        })
+        .times(1)
+        .reply(200, {
+            ...transactionsToApprove,
+        })
+
+    nock('http://localhost:14265', headers)
+        .post('/', {
+            command: IRICommand.ATTACH_TO_TANGLE,
+            trytes: [...accountASends10iToBTrytes],
+            ...transactionsToApprove,
+            minWeightMagnitude: 9,
+        })
+        .times(1)
+        .reply(200, {
+            trytes: [...accountASends10iToBTrytes],
+        })
+}
+
 describe('account.generateCDA()', async assert => {
+    const seed = 'RQMMPLNFUUCULIIHEYKYBUXUFEDPKTXDQQQRUOBUVIVWIOAXDPNHLAJDSPCXKJNPTPJYBBCJKPVMONYDK'
+
     const accountParams = {
-        seed: trytesToTrits('RQMMPLNFUUCULIIHEYKYBUXUFEDPKTXDQQQRUOBUVIVWIOAXDPNHLAJDSPCXKJNPTPJYBBCJKPVMONYDK'),
+        seed,
         persistencePath,
         emitTransferEvents: false,
     }
@@ -37,26 +158,23 @@ describe('account.generateCDA()', async assert => {
     assert({
         given: 'timeoutAt, multiUse & expectedAmount conditions',
         should: 'throw error',
-        actual: await (async () => {
-            try {
-                await account.generateCDA({
-                    timeoutAt: futureTime,
-                    multiUse: true,
-                    expectedAmount: 9,
-                })
-            } catch (error) {
-                return error.message
-            }
-        })(),
-        expected: 'Only one of the following fields can be set: multiUse, expectedAmount',
+        actual: (await Try(account.generateCDA, {
+            timeoutAt: futureTime,
+            multiUse: true,
+            expectedAmount: 9,
+        })).toString(),
+        expected: 'TypeError: Only one of the following fields can be set: multiUse, expectedAmount',
     })
 
     assert({
         given: 'timeoutAt & multiUse conditions',
         should: 'generate 1st CDA',
-        actual: await account.generateCDA({
-            timeoutAt: futureTime,
-            multiUse: false,
+        actual: await Try(() => {
+            assertRemoteSpentState(generateAddress(seed, 1, 2, false), false)
+            return account.generateCDA({
+                timeoutAt: futureTime,
+                multiUse: false,
+            })
         }),
         expected: {
             address: 'FSPPZHWG9FCUBVTNGMPIUVLMXRUAIWFEXRF9IYHPIYJRIORYOOEDBJN9WBFODDFLAKUOKYFZGDLHZNCXXPZZJZPHFT',
@@ -69,9 +187,12 @@ describe('account.generateCDA()', async assert => {
     assert({
         given: 'timeoutAt & expectedAmount conditions',
         should: 'generate 2nd CDA',
-        actual: await account.generateCDA({
-            timeoutAt: futureTime,
-            expectedAmount: 9,
+        actual: await Try(() => {
+            assertRemoteSpentState(generateAddress(seed, 2, 2, false), false)
+            return account.generateCDA({
+                timeoutAt: futureTime,
+                expectedAmount: 9,
+            })
         }),
         expected: {
             address: 'KRXPZHNMGVJKBIQXV9ALWFOPGIGNVTJFNVKHSYZLI9AABBHKSPBTKKPRVI9ID9QXXKZGTXSSSBMUQFVLWJYJMXKPRS',
@@ -82,59 +203,49 @@ describe('account.generateCDA()', async assert => {
     })
 
     assert({
+        given: 'timeoutAt & expectedAmount conditions',
+        should: 'generate 5th CDA if 3rd & 4th are spent',
+        actual: await Try(() => {
+            assertRemoteSpentState(generateAddress(seed, 3, 2, false), true)
+            assertRemoteSpentState(generateAddress(seed, 4, 2, false), true)
+            assertRemoteSpentState(generateAddress(seed, 5, 2, false), false)
+
+            return account.generateCDA({
+                timeoutAt: futureTime,
+                expectedAmount: 9,
+            })
+        }),
+        expected: {
+            address: 'AJYHQPBOFNUY9BSANYJUNAWWCIZVFVLLTWDUCN9GOMH9GAYUS9QTZITDQRIQUPGMKZZMSJMQVA999V9VX9OUCRAPFV',
+            timeoutAt: futureTime,
+            multiUse: false,
+            expectedAmount: 9,
+        },
+    })
+
+    assert({
         given: 'past time as timeoutAt',
         should: 'throw "Expired timeout" Error',
-        actual: await (async () => {
-            try {
-                await account.generateCDA({
-                    timeoutAt: pastTime,
-                    expectedAmount: 9,
-                })
-            } catch (error) {
-                return error
-            }
-        })(),
-        expected: new Error('Expired timeout'),
+        actual: (await Try(account.generateCDA, {
+            timeoutAt: pastTime,
+            expectedAmount: 9,
+        })).toString(),
+        expected: 'Error: Expired timeout.',
     })
 })
 
 describe('account.generateCDA/account.sendToCDA', async assert => {
-    // ---
-    // account 0 is poor
     const seed0 = '9'.repeat(81)
-    const address01 = generateAddress(seed0, 1, 2, false)
-    const address01has0Balance = () => {
-        return nock('http://localhost:14265', headers)
-            .post('/', {
-                command: IRICommand.GET_BALANCES,
-                addresses: [address01],
-                threshold: 100,
-            })
-            .times(1)
-            .reply(200, {
-                balances: [0],
-                milestone: 'M'.repeat(81),
-                milestoneIndex: 1,
-            })
-    }
+    const seedA = 'RQFLPKU9BIEGPPEIXEHH9RFDUMSYXMPZOVBKBITSPEFMSOIBYHMFVHRNRF9YNZYQRNBYCS9OULYHBFPHZ'
+    const seedB = 'ZKKZDWNKIWYQHCNTHKAEARYIWUYUBDWVXWWT9FQDOKPNZURMGRFJABUYTLYEQKDVJCNQYKLTVIVSTY9LI'
+
     const account0 = createAccount({
-        seed: trytesToTrits(seed0),
+        seed: trytesToTrits('9'.repeat(81)),
         persistencePath,
         emitTransferEvents: false,
         timeSource: () => BluebirdPromise.resolve(Math.floor(Date.now() / 1000)),
     })
 
-    // ---
-    // account A has 12i balance in snapshot (A1: 9i + A2: 3i), sends 10i to B, receives remainder of 3i in A3
-    const seedA = 'RQFLPKU9BIEGPPEIXEHH9RFDUMSYXMPZOVBKBITSPEFMSOIBYHMFVHRNRF9YNZYQRNBYCS9OULYHBFPHZ'
-    const addressA1 = generateAddress(seedA, 1, 2, false)
-    const addressA2 = generateAddress(seedA, 2, 2, false)
-    const addressA3 = generateAddress(seedA, 3, 2, false)
-    const addressA4 = generateAddress(seedA, 4, 2, false)
-    const balanceA1 = 9
-    const balanceA2 = 3
-    const remainderA3 = 2
-    const remainderA4 = 1
     const accountA = createAccountWithPreset({
         ...preset,
         test: {
@@ -145,74 +256,7 @@ describe('account.generateCDA/account.sendToCDA', async assert => {
         emitTransferEvents: false,
         persistencePath,
     })
-    const accountARequestedFromAnyInA1 = () =>
-        accountA.generateCDA({
-            timeoutAt: Math.floor(Date.now() / 1000) + 5,
-            multiUse: true,
-        })
-    const accountARequestedFromAnyInA2 = () =>
-        accountA.generateCDA({
-            timeoutAt: futureTime,
-            expectedAmount: balanceA2,
-        })
-    const accountAHas9iInA1 = () =>
-        nock('http://localhost:14265', headers)
-            .post('/', {
-                command: IRICommand.GET_BALANCES,
-                addresses: [addressA1],
-                threshold: 100,
-            })
-            .times(1)
-            .reply(200, {
-                balances: [balanceA1],
-                milestone: 'M'.repeat(81),
-                milestoneIndex: 1,
-            })
-    const accountAHas3iInA2 = () =>
-        nock('http://localhost:14265', headers)
-            .post('/', {
-                command: IRICommand.GET_BALANCES,
-                addresses: [addressA2],
-                threshold: 100,
-            })
-            .times(1)
-            .reply(200, {
-                balances: [balanceA2],
-                milestone: 'M'.repeat(81),
-                milestoneIndex: 1,
-            })
 
-    const accountARemainder3ReceivesExpectedBalance = () =>
-        nock('http://localhost:14265', headers)
-            .post('/', {
-                command: IRICommand.GET_BALANCES,
-                addresses: [addressA3],
-                threshold: 100,
-            })
-            .times(1)
-            .reply(200, {
-                balances: [remainderA3],
-                milestone: 'M'.repeat(81),
-                milestoneIndex: 1,
-            })
-
-    const accountARemainder4ReceivesExpectedBalance = () =>
-        nock('http://localhost:14265', headers)
-            .post('/', {
-                command: IRICommand.GET_BALANCES,
-                addresses: [addressA4],
-                threshold: 100,
-            })
-            .times(1)
-            .reply(200, {
-                balances: [remainderA4],
-                milestone: 'M'.repeat(81),
-                milestoneIndex: 1,
-            })
-
-    // ---
-    // account B requests from 0 and A, receives from A
-    const seedB = 'ZKKZDWNKIWYQHCNTHKAEARYIWUYUBDWVXWWT9FQDOKPNZURMGRFJABUYTLYEQKDVJCNQYKLTVIVSTY9LI'
     const accountB = createAccountWithPreset({
         ...preset,
         now: () => futureTime,
@@ -222,205 +266,106 @@ describe('account.generateCDA/account.sendToCDA', async assert => {
         persistencePath,
     })
 
-    const addressB1 = generateAddress(seedB, 1, 2, false)
-    const addressB2 = generateAddress(seedB, 2, 2, false)
-    const addressB3 = generateAddress(seedB, 3, 2, false)
+    assertRemoteSpentState(generateAddress(seedA, 1, 2, false), false)
+    const A1 = await accountA.generateCDA({
+        timeoutAt: Math.floor(Date.now() / 1000) + 5,
+        multiUse: true,
+    })
 
-    // request from 0 and A
-    let cdaB1
-    const accountBRequestsFromAny = () =>
-        accountB.generateCDA({
-            timeoutAt: futureTime,
-            multiUse: true,
-        })
+    assertRemoteSpentState(generateAddress(seedA, 2, 2, false), false)
+    const A2 = await accountA.generateCDA({
+        timeoutAt: futureTime,
+        expectedAmount: 3,
+    })
 
-    // request 9i from A
-    const accountBRequests10iFromAccountA = () =>
-        accountB.generateCDA({
-            timeoutAt: futureTime,
-            expectedAmount: 10,
-        })
+    assertRemoteSpentState(generateAddress(seedB, 1, 2, false), false)
+    const B1 = await accountB.generateCDA({
+        timeoutAt: futureTime,
+        multiUse: true,
+    })
 
-    cdaB1 = await accountBRequestsFromAny()
+    assertRemoteSpentState(generateAddress(seedB, 2, 2, false), false)
+    const B2 = await accountB.generateCDA({
+        timeoutAt: futureTime,
+        expectedAmount: 10,
+    })
 
-    const assertRemoteSpentState = (address: string, state: boolean) =>
-        nock('http://localhost:14265', headers)
-            .post('/', {
-                command: IRICommand.WERE_ADDRESSES_SPENT_FROM,
-                addresses: [address],
-            })
-            .times(1)
-            .reply(200, {
-                states: [state],
-            })
-
-    const accountASends10iToB = (cda: CDA) => {
-        const hash = 'ZZKVOZRYHZVYORKHDLWRNIWKWLZMVBNFSPQC99PYHVJFRYRHXVUTHPQOVPJBRNFLYWDNKBBUJOTDQVTDE'
-        const transactionsToApprove = {
-            trunkTransaction: '9'.repeat(81),
-            branchTransaction: '9'.repeat(81),
-        }
-
-        nock('http://localhost:14265', headers)
-            .post('/', {
-                command: IRICommand.FIND_TRANSACTIONS,
-                addresses: [cda.address.slice(0, 81)],
-            })
-            .times(1)
-            .reply(200, {
-                hashes: [hash],
-            })
-
-        nock('http://localhost:14265', headers)
-            .post('/', {
-                command: IRICommand.GET_TRYTES,
-                hashes: [hash],
-            })
-            .times(1)
-            .reply(200, {
-                trytes: [accountASends10iToBTrytes[0]],
-            })
-
-        nock('http://localhost:14265', headers)
-            .persist()
-            .post('/', { command: IRICommand.GET_NODE_INFO })
-            .reply(200, {
-                appName: 'IRI',
-                appVersion: '',
-                duration: 100,
-                jreAvailableProcessors: 4,
-                jreFreeMemory: 13020403,
-                jreMaxMemory: 1241331231,
-                jreTotalMemory: 4245234332,
-                latestMilestone: 'M'.repeat(81),
-                latestMilestoneIndex: 1,
-                latestSolidSubtangleMilestone: 'M'.repeat(81),
-                latestSolidSubtangleMilestoneIndex: 1,
-                neighbors: 5,
-                packetsQueueSize: 23,
-                time: 213213214,
-                tips: 123,
-                transactionsToRequest: 10,
-            })
-
-        nock('http://localhost:14265', headers)
-            .post('/', {
-                command: IRICommand.GET_INCLUSION_STATES,
-                transactions: [hash],
-                tips: ['M'.repeat(81)],
-            })
-            .times(1)
-            .reply(200, {
-                states: [false],
-            })
-
-        nock('http://localhost:14265', headers)
-            .post('/', {
-                command: IRICommand.CHECK_CONSISTENCY,
-                tails: [hash],
-            })
-            .times(1)
-            .reply(200, {
-                states: [false],
-            })
-
-        nock('http://localhost:14265', headers)
-            .post('/', {
-                command: IRICommand.GET_TRANSACTIONS_TO_APPROVE,
-                depth: 3,
-            })
-            .times(1)
-            .reply(200, {
-                ...transactionsToApprove,
-            })
-
-        nock('http://localhost:14265', headers)
-            .post('/', {
-                command: IRICommand.ATTACH_TO_TANGLE,
-                trytes: [...accountASends10iToBTrytes],
-                ...transactionsToApprove,
-                minWeightMagnitude: 9,
-            })
-            .times(1)
-            .reply(200, {
-                trytes: [...accountASends10iToBTrytes],
-            })
-    }
-
-    assert({
-        given: 'that account0 has 0 persisted CDAs, sendToCDA',
-        should: 'throw "Insufficient balance" error',
-        actual: await (async () => {
-            try {
-                await assertRemoteSpentState(addressB1, false)
-                return await account0.sendToCDA({ ...cdaB1, value: 1 })
-            } catch (error) {
-                return error.message
-            }
-        })(),
-        expected: 'Insufficient balance',
+    assertRemoteSpentState(generateAddress(seedB, 3, 2, false), false)
+    const B3 = await accountB.generateCDA({
+        timeoutAt: futureTime,
+        expectedAmount: 1,
+        multiUse: false,
     })
 
     assert({
-        given: 'that account0 has 1 persisted, unfunded CDA, sendToCDA',
+        given: 'that account has 0 persisted CDAs, sendToCDA',
         should: 'throw "Insufficient balance" error',
-        actual: await (async () => {
-            try {
-                await address01has0Balance()
-                await account0.generateCDA({
-                    timeoutAt: futureTime,
-                    multiUse: true,
-                })
+        actual: (await Try(() => {
+            assertRemoteSpentState(B1.address, false)
+            return account0.sendToCDA({ ...B1, value: 1 })
+        })).toString(),
+        expected: 'Error: Insufficient balance',
+    })
 
-                await assertRemoteSpentState(addressB1, false)
-                return await account0.sendToCDA({ ...cdaB1, value: 1 })
-            } catch (error) {
-                return error.message
-            }
-        })(),
-        expected: 'Insufficient balance',
+    assert({
+        given: 'an expired CDA, sendToCDA',
+        should: 'throw "Expired timeout" error',
+        actual: (await Try(() => {
+            const address = 'A'.repeat(90)
+            assertRemoteSpentState(address, false)
+            return account0.sendToCDA({ address, timeoutAt: pastTime, value: 1 })
+        })).toString(),
+        expected: 'Error: Expired timeout.',
+    })
+
+    assert({
+        given: 'that account has 1 persisted, unfunded CDA, sendToCDA',
+        should: 'throw "Insufficient balance" error',
+        actual: (await Try(async () => {
+            assertRemoteSpentState(generateAddress(seed0, 1, 2, false), false)
+            const cda = await account0.generateCDA({
+                timeoutAt: futureTime,
+                multiUse: true,
+            })
+            const value = 1
+
+            assertBalance(cda.address, value - 1)
+            assertRemoteSpentState(B1.address, false)
+
+            return account0.sendToCDA({ ...B1, value })
+        })).toString(),
+        expected: 'Error: Insufficient balance',
     })
 
     assert({
         given: 'that account A has 12i balance in snapshot (A1: 9i, A2: 3i)',
         should: 'send 10i to B',
-        actual: await (async () => {
-            try {
-                await accountARequestedFromAnyInA1()
-                await accountARequestedFromAnyInA2()
-                await accountAHas9iInA1()
-                await accountAHas3iInA2()
-                await assertRemoteSpentState(addressB2, false)
-                await delay(5500)
-                const cdaB2 = await accountBRequests10iFromAccountA()
-                await accountASends10iToB(cdaB2)
-                return await accountA.sendToCDA({
-                    ...cdaB2,
-                    value: cdaB2.expectedAmount,
-                })
-            } catch (error) {
-                return error.message
-            }
-        })(),
+        actual: await Try(() => {
+            assertBalance(A1.address, 9)
+            assertBalance(A2.address, 3)
+            assertTransfer(B2, accountASends10iToBTrytes)
+            assertRemoteSpentState(B2.address, false)
+
+            return accountA.sendToCDA({
+                ...B2,
+                value: B2.expectedAmount,
+            })
+        }),
         expected: accountASends10iToBTrytes,
     })
 
     assert({
         given: 'that previous transfer of 10i to B is included, account A',
         should: 'be able to spend 1i from remainder address A3',
-        actual: await (async () => {
-            try {
-                await accountARemainder3ReceivesExpectedBalance()
-                await assertRemoteSpentState(addressB1, false)
+        actual: await Try(() => {
+            assertBalance(generateAddress(seedA, 3, 2, false), 2)
+            assertRemoteSpentState(B1.address, false)
 
-                return await accountA.sendToCDA({
-                    ...cdaB1,
-                    value: 1,
-                })
-            } catch (error) {
-                return error.message
-            }
-        })(),
+            return accountA.sendToCDA({
+                ...B1,
+                value: 1,
+            })
+        }),
         expected: accountASpendsFromRemainderTrytes,
     })
 
@@ -428,63 +373,49 @@ describe('account.generateCDA/account.sendToCDA', async assert => {
         given:
             'that account A has used all inputs in previous transfers (except one with insufficient balance of 1i), sendToCDA',
         should: 'throw "insufficient balance" error',
-        actual: await (async () => {
-            try {
-                await accountARemainder4ReceivesExpectedBalance()
-                await assertRemoteSpentState(addressB1, false)
+        actual: (await Try(() => {
+            assertBalance(generateAddress(seedA, 4, 2, false), 1)
+            assertRemoteSpentState(B1.address, false)
 
-                return await accountA.sendToCDA({
-                    ...cdaB1,
-                    value: 2,
-                })
-            } catch (error) {
-                return error.message
-            }
-        })(),
-        expected: 'Insufficient balance',
+            return accountA.sendToCDA({
+                ...B1,
+                value: 2,
+            })
+        })).toString(),
+        expected: 'Error: Insufficient balance',
     })
 
     assert({
         given: 'that CDA is spent from',
         should: 'throw error',
-        actual: await (async () => {
-            try {
-                await assertRemoteSpentState(addressB1, true)
+        actual: (await Try(() => {
+            assertRemoteSpentState(B1.address, true)
 
-                return await accountA.sendToCDA({
-                    ...cdaB1,
-                    value: 2,
-                })
-            } catch (error) {
-                return error.message
-            }
-        })(),
-        expected: `Aborted sending to spent address; ${addressB1}`,
+            return accountA.sendToCDA({
+                ...B1,
+                value: 2,
+            })
+        })).toString(),
+        expected: `Error: Aborted sending to spent address; ${noChecksum(B1.address)}`,
     })
 
     assert({
         given: 'a CDA with multiUse=false',
         should: 'allow only one transfer',
-        actual: await (async () => {
-            try {
-                const cdaB3 = await accountB.generateCDA({
-                    timeoutAt: futureTime,
-                    expectedAmount: 1,
-                    multiUse: false,
-                })
-                const transfer = { ...cdaB3, value: 1 }
+        actual: (await Try(async () => {
+            const value = 1
+            const transfer = { ...B3, value }
 
-                await accountARemainder4ReceivesExpectedBalance()
-                await assertRemoteSpentState(addressB3, false)
-                await accountA.sendToCDA(transfer)
+            const address = generateAddress(seedA, 4, 2, false)
 
-                await accountARemainder4ReceivesExpectedBalance()
-                await assertRemoteSpentState(addressB3, false)
-                await accountA.sendToCDA(transfer)
-            } catch (error) {
-                return error.message
-            }
-        })(),
-        expected: `Aborted sending twice to the same address; ${addressB3}`,
+            assertBalance(address, value)
+            assertRemoteSpentState(B3.address, false)
+            await accountA.sendToCDA(transfer)
+
+            assertBalance(address, value)
+            assertRemoteSpentState(B3.address, false)
+            return accountA.sendToCDA(transfer)
+        })).toString(),
+        expected: `Error: Aborted sending twice to the same address; ${noChecksum(B3.address)}`,
     })
 })


### PR DESCRIPTION
# Description
- Adds `wereAddressesSpentFrom` check in address generation. In case a seed is opened in more than one device, this check might prevent key/address reuse.

- Refactors account test file

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Unit test


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes