### PR TITLE
fix(account): skip used addresses & emit error

### DIFF
--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -23,6 +23,7 @@ export interface AddressGenerationParams {
     readonly timeSource: TimeSource
     readonly network: Network
 }
+
 export interface TransactionIssuanceParams {
     readonly seed: Int8Array
     readonly deposits: AsyncBuffer<Int8Array>
@@ -89,6 +90,9 @@ export interface Network {
     readonly attachToTangle: API['attachToTangle']
     readonly getBundlesFromAddresses: API['getBundlesFromAddresses']
     readonly wereAddressesSpentFrom: API['wereAddressesSpentFrom']
+    readonly isAddressUsed: (
+        address: Trytes
+    ) => Promise<{ isUsed: boolean; isSpent: boolean; transactions: ReadonlyArray<Trytes> }>
 }
 export interface TransactionAttachment {
     readonly startAttaching: (params: TransactionAttachmentStartParams) => void

--- a/packages/account/src/preset.ts
+++ b/packages/account/src/preset.ts
@@ -118,7 +118,7 @@ export function addressGeneration(this: any, addressGenerationParams: AddressGen
 
                 return network.isAddressUsed(addressTrytes).then(({ isUsed, isSpent, transactions }) => {
                     if (isUsed) {
-                        emitter.emit('error', new Error('Dropping used address.'), {
+                        emitter.emit('error', new Error('Dropped used address.'), {
                             address: addressTrytes,
                             isSpent,
                             transactions,
@@ -248,6 +248,9 @@ export function transactionIssuance(
             )
         },
     }
+
+    const emitter = this // tslint:disable-line
+
     function accumulateInputs(
         threshold: number,
         acc: CDAInputs = { inputs: [], totalBalance: 0 },
@@ -304,20 +307,33 @@ export function transactionIssuance(
         return persistence.increment().then(index => {
             const security = 2
             const remainderAddress = signingAddress(digests(key(subseed(seed, tritsToValue(index)), security)))
+            const addressTrytes = tritsToTrytes(remainderAddress)
 
-            return persistence
-                .put(
-                    ['0', tritsToTrytes(remainderAddress)].join(':'),
-                    serializeCDAInput({
-                        address: remainderAddress,
-                        index,
-                        security,
-                        timeoutAt: 0,
-                        multiUse: false,
-                        expectedAmount: remainder,
+            return network.isAddressUsed(addressTrytes).then(({ isUsed, isSpent, transactions }) => {
+                if (isUsed) {
+                    emitter.emit('error', new Error('Dropped used address.'), {
+                        address: addressTrytes,
+                        isSpent,
+                        transactions,
                     })
-                )
-                .then(() => tritsToTrytes(remainderAddress))
+
+                    return generateRemainderAddress(remainder)
+                }
+
+                return persistence
+                    .put(
+                        ['0', tritsToTrytes(remainderAddress)].join(':'),
+                        serializeCDAInput({
+                            address: remainderAddress,
+                            index,
+                            security,
+                            timeoutAt: 0,
+                            multiUse: false,
+                            expectedAmount: remainder,
+                        })
+                    )
+                    .then(() => tritsToTrytes(remainderAddress))
+            })
         })
     }
 

--- a/packages/account/test/account.test.ts
+++ b/packages/account/test/account.test.ts
@@ -26,6 +26,17 @@ const headers = {
     },
 }
 
+const assertAddressTransactions = (address: Trytes, hashes: Trytes[]) =>
+    nock('http://localhost:14265', headers)
+        .post('/', {
+            command: IRICommand.FIND_TRANSACTIONS,
+            addresses: [noChecksum(address)],
+        })
+        .times(1)
+        .reply(200, {
+            hashes,
+        })
+
 const assertRemoteSpentState = (address: Trytes, state: boolean) =>
     nock('http://localhost:14265', headers)
         .post('/', {
@@ -58,15 +69,7 @@ const assertTransfer = (transfer: CDATransfer, trytes: Trytes[]) => {
         branchTransaction: '9'.repeat(81),
     }
 
-    nock('http://localhost:14265', headers)
-        .post('/', {
-            command: IRICommand.FIND_TRANSACTIONS,
-            addresses: [noChecksum(transfer.address)],
-        })
-        .times(1)
-        .reply(200, {
-            hashes: [hash],
-        })
+    assertAddressTransactions(transfer.address, [hash])
 
     nock('http://localhost:14265', headers)
         .post('/', {
@@ -170,7 +173,11 @@ describe('account.generateCDA()', async assert => {
         given: 'timeoutAt & multiUse conditions',
         should: 'generate 1st CDA',
         actual: await Try(() => {
-            assertRemoteSpentState(generateAddress(seed, 1, 2, false), false)
+            const address = generateAddress(seed, 1, 2, false)
+
+            assertRemoteSpentState(address, false)
+            assertAddressTransactions(address, [])
+
             return account.generateCDA({
                 timeoutAt: futureTime,
                 multiUse: false,
@@ -188,7 +195,11 @@ describe('account.generateCDA()', async assert => {
         given: 'timeoutAt & expectedAmount conditions',
         should: 'generate 2nd CDA',
         actual: await Try(() => {
-            assertRemoteSpentState(generateAddress(seed, 2, 2, false), false)
+            const address = generateAddress(seed, 2, 2, false)
+
+            assertRemoteSpentState(address, false)
+            assertAddressTransactions(address, [])
+
             return account.generateCDA({
                 timeoutAt: futureTime,
                 expectedAmount: 9,
@@ -206,9 +217,18 @@ describe('account.generateCDA()', async assert => {
         given: 'timeoutAt & expectedAmount conditions',
         should: 'generate 5th CDA if 3rd & 4th are spent',
         actual: await Try(() => {
-            assertRemoteSpentState(generateAddress(seed, 3, 2, false), true)
-            assertRemoteSpentState(generateAddress(seed, 4, 2, false), true)
-            assertRemoteSpentState(generateAddress(seed, 5, 2, false), false)
+            const c = generateAddress(seed, 3, 2, false)
+            const d = generateAddress(seed, 4, 2, false)
+            const e = generateAddress(seed, 5, 2, false)
+
+            assertRemoteSpentState(c, true)
+            assertAddressTransactions(c, [])
+
+            assertRemoteSpentState(d, false)
+            assertAddressTransactions(d, ['9'.repeat(81)])
+
+            assertRemoteSpentState(e, false)
+            assertAddressTransactions(e, [])
 
             return account.generateCDA({
                 timeoutAt: futureTime,
@@ -266,31 +286,41 @@ describe('account.generateCDA/account.sendToCDA', async assert => {
         persistencePath,
     })
 
-    assertRemoteSpentState(generateAddress(seedA, 1, 2, false), false)
+    const a1 = generateAddress(seedA, 1, 2, false)
+    assertRemoteSpentState(a1, false)
+    assertAddressTransactions(a1, [])
     const A1 = await accountA.generateCDA({
         timeoutAt: Math.floor(Date.now() / 1000) + 5,
         multiUse: true,
     })
 
-    assertRemoteSpentState(generateAddress(seedA, 2, 2, false), false)
+    const a2 = generateAddress(seedA, 2, 2, false)
+    assertRemoteSpentState(a2, false)
+    assertAddressTransactions(a2, [])
     const A2 = await accountA.generateCDA({
         timeoutAt: futureTime,
         expectedAmount: 3,
     })
 
-    assertRemoteSpentState(generateAddress(seedB, 1, 2, false), false)
+    const b1 = generateAddress(seedB, 1, 2, false)
+    assertRemoteSpentState(b1, false)
+    assertAddressTransactions(b1, [])
     const B1 = await accountB.generateCDA({
         timeoutAt: futureTime,
         multiUse: true,
     })
 
-    assertRemoteSpentState(generateAddress(seedB, 2, 2, false), false)
+    const b2 = generateAddress(seedB, 2, 2, false)
+    assertRemoteSpentState(b2, false)
+    assertAddressTransactions(b2, [])
     const B2 = await accountB.generateCDA({
         timeoutAt: futureTime,
         expectedAmount: 10,
     })
 
-    assertRemoteSpentState(generateAddress(seedB, 3, 2, false), false)
+    const b3 = generateAddress(seedB, 3, 2, false)
+    assertRemoteSpentState(b3, false)
+    assertAddressTransactions(b3, [])
     const B3 = await accountB.generateCDA({
         timeoutAt: futureTime,
         expectedAmount: 1,
@@ -302,6 +332,7 @@ describe('account.generateCDA/account.sendToCDA', async assert => {
         should: 'throw "Insufficient balance" error',
         actual: (await Try(() => {
             assertRemoteSpentState(B1.address, false)
+            assertAddressTransactions(B1.address, [])
             return account0.sendToCDA({ ...B1, value: 1 })
         })).toString(),
         expected: 'Error: Insufficient balance',
@@ -322,7 +353,11 @@ describe('account.generateCDA/account.sendToCDA', async assert => {
         given: 'that account has 1 persisted, unfunded CDA, sendToCDA',
         should: 'throw "Insufficient balance" error',
         actual: (await Try(async () => {
-            assertRemoteSpentState(generateAddress(seed0, 1, 2, false), false)
+            const address = generateAddress(seed0, 1, 2, false)
+
+            assertRemoteSpentState(address, false)
+            assertAddressTransactions(address, [])
+
             const cda = await account0.generateCDA({
                 timeoutAt: futureTime,
                 multiUse: true,
@@ -374,7 +409,9 @@ describe('account.generateCDA/account.sendToCDA', async assert => {
             'that account A has used all inputs in previous transfers (except one with insufficient balance of 1i), sendToCDA',
         should: 'throw "insufficient balance" error',
         actual: (await Try(() => {
-            assertBalance(generateAddress(seedA, 4, 2, false), 1)
+            const input = generateAddress(seedA, 4, 2, false)
+
+            assertBalance(input, 1)
             assertRemoteSpentState(B1.address, false)
 
             return accountA.sendToCDA({

--- a/packages/account/test/account.test.ts
+++ b/packages/account/test/account.test.ts
@@ -302,6 +302,9 @@ describe('account.generateCDA/account.sendToCDA', async assert => {
         expectedAmount: 3,
     })
 
+    const a3 = generateAddress(seedA, 3, 2, false)
+    const a4 = generateAddress(seedA, 4, 2, false)
+
     const b1 = generateAddress(seedB, 1, 2, false)
     assertRemoteSpentState(b1, false)
     assertAddressTransactions(b1, [])
@@ -378,6 +381,8 @@ describe('account.generateCDA/account.sendToCDA', async assert => {
         actual: await Try(() => {
             assertBalance(A1.address, 9)
             assertBalance(A2.address, 3)
+            assertRemoteSpentState(a3, false)
+            assertAddressTransactions(a3, [])
             assertTransfer(B2, accountASends10iToBTrytes)
             assertRemoteSpentState(B2.address, false)
 
@@ -393,7 +398,9 @@ describe('account.generateCDA/account.sendToCDA', async assert => {
         given: 'that previous transfer of 10i to B is included, account A',
         should: 'be able to spend 1i from remainder address A3',
         actual: await Try(() => {
-            assertBalance(generateAddress(seedA, 3, 2, false), 2)
+            assertBalance(a3, 2)
+            assertRemoteSpentState(a4, false)
+            assertAddressTransactions(a4, [])
             assertRemoteSpentState(B1.address, false)
 
             return accountA.sendToCDA({
@@ -409,9 +416,7 @@ describe('account.generateCDA/account.sendToCDA', async assert => {
             'that account A has used all inputs in previous transfers (except one with insufficient balance of 1i), sendToCDA',
         should: 'throw "insufficient balance" error',
         actual: (await Try(() => {
-            const input = generateAddress(seedA, 4, 2, false)
-
-            assertBalance(input, 1)
+            assertBalance(a4, 1)
             assertRemoteSpentState(B1.address, false)
 
             return accountA.sendToCDA({
@@ -443,13 +448,11 @@ describe('account.generateCDA/account.sendToCDA', async assert => {
             const value = 1
             const transfer = { ...B3, value }
 
-            const address = generateAddress(seedA, 4, 2, false)
-
-            assertBalance(address, value)
+            assertBalance(a4, value)
             assertRemoteSpentState(B3.address, false)
             await accountA.sendToCDA(transfer)
 
-            assertBalance(address, value)
+            assertBalance(a4, value)
             assertRemoteSpentState(B3.address, false)
             return accountA.sendToCDA(transfer)
         })).toString(),

--- a/packages/core/src/createGetNewAddress.ts
+++ b/packages/core/src/createGetNewAddress.ts
@@ -2,7 +2,7 @@ import { addChecksum } from '@iota/checksum'
 import * as Promise from 'bluebird'
 import * as errors from '../../errors'
 import { indexValidator, securityLevelValidator, seedValidator, validate } from '../../guards'
-import { asArray, Callback, getOptionsWithDefaults, Provider, Trytes } from '../../types'
+import { Callback, getOptionsWithDefaults, Provider, Trytes } from '../../types'
 import { createFindTransactions, generateAddress } from './'
 import { createWereAddressesSpentFrom } from './createWereAddressesSpentFrom'
 

--- a/packages/core/src/createGetNewAddress.ts
+++ b/packages/core/src/createGetNewAddress.ts
@@ -16,14 +16,23 @@ export interface GetNewAddressOptions {
 
 export type GetNewAddressResult = Trytes | ReadonlyArray<Trytes>
 
+export interface AddressState {
+    readonly isUsed: boolean
+    readonly isSpent: boolean
+    readonly transactions: ReadonlyArray<Trytes>
+}
+
 export const createIsAddressUsed = (provider: Provider) => {
     const wereAddressesSpentFrom = createWereAddressesSpentFrom(provider, 'lib')
     const findTransactions = createFindTransactions(provider)
 
-    return (address: Trytes) =>
-        wereAddressesSpentFrom(asArray(address)).then(
-            ([spent]) =>
-                spent || findTransactions({ addresses: asArray(address) }).then(transactions => transactions.length > 0)
+    return (address: Trytes): Promise<AddressState> =>
+        wereAddressesSpentFrom([address]).then(([isSpent]) =>
+            findTransactions({ addresses: [address] }).then(transactions => ({
+                isUsed: isSpent || transactions.length > 0,
+                isSpent,
+                transactions,
+            }))
         )
 }
 
@@ -50,7 +59,7 @@ export const createIsAddressUsed = (provider: Provider) => {
  * - Fetch error
  */
 export const getUntilFirstUnusedAddress = (
-    isAddressUsed: (address: Trytes) => Promise<boolean>,
+    isAddressUsed: (address: Trytes) => Promise<AddressState>,
     seed: Trytes,
     index: number,
     security: number,
@@ -65,8 +74,8 @@ export const getUntilFirstUnusedAddress = (
             addressList.push(nextAddress)
         }
 
-        return isAddressUsed(nextAddress).then(used => {
-            if (used) {
+        return isAddressUsed(nextAddress).then(({ isUsed }) => {
+            if (isUsed) {
                 return iterate()
             }
 
@@ -187,11 +196,10 @@ export const createGetNewAddress = (provider: Provider, caller?: string) => {
                 (!!total || total === 0) && [total, t => Number.isInteger(t) && t > 0, errors.INVALID_TOTAL_OPTION]
             )
         )
-            .then(
-                () =>
-                    total && total > 0
-                        ? generateAddresses(seed, index, security, total)
-                        : Promise.try(getUntilFirstUnusedAddress(isAddressUsed, seed, index, security, returnAll))
+            .then(() =>
+                total && total > 0
+                    ? generateAddresses(seed, index, security, total)
+                    : Promise.try(getUntilFirstUnusedAddress(isAddressUsed, seed, index, security, returnAll))
             )
             .then(applyReturnAllOption(returnAll, total))
             .then(applyChecksumOption(checksum))

--- a/packages/core/test/integration/getNewAddress.test.ts
+++ b/packages/core/test/integration/getNewAddress.test.ts
@@ -91,11 +91,23 @@ test.cb('getNewAddress() passes correct arguments to callback', t => {
 })
 
 test('isAddressUsed() resolves to correct state', async t => {
-    t.is(await isAddressUsed(addresses[0]), true, 'isAddressUsed() resolves to `true` for spent address')
+    t.deepEqual(
+        await isAddressUsed(addresses[0]),
+        { isUsed: true, isSpent: true, transactions: [] },
+        'isAddressUsed() resolves to `true` for spent address'
+    )
 
-    t.is(await isAddressUsed(addresses[1]), true, 'isAddressUsed() resolves to `true` for address with transactions')
+    t.deepEqual(
+        await isAddressUsed(addresses[1]),
+        { isUsed: true, isSpent: false, transactions: ['A'.repeat(81), 'B'.repeat(81)] },
+        'isAddressUsed() resolves to `true` for address with transactions'
+    )
 
-    t.is(await isAddressUsed(addresses[1]), true, 'isAddressUsed() resolves to `false` result for unused address')
+    t.deepEqual(
+        await isAddressUsed(addresses[2]),
+        { isUsed: false, isSpent: false, transactions: [] },
+        'isAddressUsed() resolves to `false` result for unused address'
+    )
 })
 
 test('getUntilFirstUnusedAddress() resolves to correct new address', async t => {

--- a/packages/core/test/integration/nocks/findTransactions.ts
+++ b/packages/core/test/integration/nocks/findTransactions.ts
@@ -100,3 +100,11 @@ nock('http://localhost:14265', headers)
         addresses: [addresses[1], addresses[2]],
     })
     .reply(200, findTransactionsResponse)
+
+nock('http://localhost:14265', headers)
+    .persist()
+    .post('/', {
+        command: IRICommand.FIND_TRANSACTIONS,
+        addresses: [addresses[0]],
+    })
+    .reply(200, emptyFindTransactionsResponse)

--- a/packages/core/test/integration/prepareTransfers.test.ts
+++ b/packages/core/test/integration/prepareTransfers.test.ts
@@ -6,6 +6,7 @@ import { stringify } from '../../../guards'
 import { Transfer, Trytes } from '../../../types'
 import { createPrepareTransfers } from '../../src'
 import { getRemainderAddressStartIndex } from '../../src/createPrepareTransfers'
+import './nocks/findTransactions'
 import './nocks/prepareTransfers'
 
 const inputs: ReadonlyArray<any> = [
@@ -116,11 +117,13 @@ test('prepareTransfers() throws intuitive error when provided invalid transfers 
 })
 
 test('prepareTransfers() throws error for inputs without security level.', async t => {
-    const input: any = [{
-        address: 'I'.repeat(81),
-        keyIndex: 0,
-        balance: 1,
-    }]
+    const input: any = [
+        {
+            address: 'I'.repeat(81),
+            keyIndex: 0,
+            balance: 1,
+        },
+    ]
 
     t.is(
         t.throws(() =>


### PR DESCRIPTION
# Description

- Modifies return type of `isUsedAddress()` to return spent status and list of associated transaction hashes.
- Changes `generateCDA()` to check for transactions on new addresses (besides spent states). If any transactions exist, the address is skipped. In case two (or more) accounts access the same seed, this check might be able to prevent reuse.
- Changes `generateRemainderAddress()` to skip used addresses.
- Emits error events containing the spent state & list of transactions for each used address that is  being skipped.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Integration tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes