### PR TITLE
fix(account): attach new address to tangle

### DIFF
--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -22,6 +22,7 @@ export interface AddressGenerationParams {
     readonly persistence: Persistence<string, Int8Array>
     readonly timeSource: TimeSource
     readonly network: Network
+    readonly now: () => number // testing only
 }
 export interface TransactionIssuanceParams {
     readonly seed: Int8Array
@@ -199,6 +200,7 @@ export function createAccountWithPreset<X, Y, Z>(preset: AccountPreset<X, Y, Z>)
                     timeSource,
                     security: preset.security,
                     network,
+                    now: preset.test.now,
                 }),
                 preset.transactionIssuance.call(this, {
                     seed: seed as Int8Array,

--- a/packages/account/test/account.test.ts
+++ b/packages/account/test/account.test.ts
@@ -232,6 +232,25 @@ describe('account.generateCDA()', async assert => {
         })).toString(),
         expected: 'Error: Expired timeout.',
     })
+
+    /*
+    const s = ''
+    const acc = createAccount({
+        seed: s,
+        persistencePath,
+        provider: '',
+    })
+
+    assert({
+        given: 'a new address',
+        should: 'attach it to tangle',
+        actual: await Try(async () => {
+            const { address } = await acc.generateCDA({ timeoutAt: futureTime, expectedAmount: 1 })
+            return new Promise(resolve => acc.on('attachToTangle', ([tail]) => resolve(tail.address)))
+        }),
+        expected: generateAddress(s, 1, 2, false),
+    })
+    */
 })
 
 describe('account.generateCDA/account.sendToCDA', async assert => {


### PR DESCRIPTION
# Description

Attaches generated addresses to tangle until inclusion. Being the other half to #446 this change attempts to notify other wallets using the same seed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manually tested, integration test to be added.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes