### PR TITLE
fix(account): drop spent inputs & emit error

### DIFF
--- a/packages/account/test/account.test.ts
+++ b/packages/account/test/account.test.ts
@@ -308,7 +308,7 @@ describe('account.generateCDA/account.sendToCDA', async assert => {
     const a1 = generateAddress(seedA, 1, 2, false)
     assertRemoteSpentState(a1, false)
     assertAddressTransactions(a1, [])
-    const A1 = await accountA.generateCDA({
+    await accountA.generateCDA({
         timeoutAt: Math.floor(Date.now() / 1000) + 5,
         multiUse: true,
     })
@@ -316,7 +316,7 @@ describe('account.generateCDA/account.sendToCDA', async assert => {
     const a2 = generateAddress(seedA, 2, 2, false)
     assertRemoteSpentState(a2, false)
     assertAddressTransactions(a2, [])
-    const A2 = await accountA.generateCDA({
+    await accountA.generateCDA({
         timeoutAt: futureTime,
         expectedAmount: 3,
     })


### PR DESCRIPTION
# Description

Lazily checks if inputs with balance have been spent from, before using them in transactions.
Then it drops such inputs and an error event is emitted containing the spent address and its balance.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Integration tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes