### PR TITLE
feat(account): persist spent address

### DIFF
--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -375,6 +375,11 @@ export function createAccountWithPreset<X, Y, Z>(preset: AccountPreset<X, Y, Z>)
                     depositsList.push(cda)
                     addresses.push(tritsToTrytes(cda.address))
                 }
+
+                if (trits.length === 1) {
+                    // used address, don't list it as deposit or pass it to input selection
+                    addresses.push(id)
+                }
             } else if (prefix === SENT_TO_ADDRESS_PREFIX) {
                 timeSource().then(now => {
                     if (tritsToValue(trits) <= now) {

--- a/packages/account/test/account.test.ts
+++ b/packages/account/test/account.test.ts
@@ -430,7 +430,7 @@ describe('account.generateCDA/account.sendToCDA', async assert => {
         expected: {
             rejected: 'Error: Insufficient balance',
             emitted: {
-                error: 'Error: Dropped spent input.',
+                error: 'Error: Skipping spent input.',
                 address: generateAddress(seed0, 1, 2, false),
                 balance: 1,
             },


### PR DESCRIPTION
# Description

Persists trytes of spent addresses but removes their conditions, if any. This change allows to continue monitoring addresses for transactions and emit events with the history of the account. 

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] CI must pass

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes