### PR TITLE
feat(bundle): allow to specify number of fragments to be signed

### DIFF
--- a/packages/bundle/src/index.ts
+++ b/packages/bundle/src/index.ts
@@ -2,7 +2,7 @@
 
 import { tritsToValue } from '@iota/converter'
 import Kerl from '@iota/kerl'
-import { increment, MAX_TRYTE_VALUE, normalizedBundle } from '@iota/signing'
+import { increment, MAX_TRYTE_VALUE, NORMALIZED_FRAGMENT_LENGTH, normalizedBundle } from '@iota/signing'
 import * as errors from '../../errors'
 import '../../typed-array'
 
@@ -193,9 +193,11 @@ export const addEntry = (bundle: Int8Array, entry: Partial<BundleEntry>): Int8Ar
  *
  * @param {Int8Array} bundle - Bundle transaction trits
  *
+ * @param {number} [numberOfFragments=3]
+ *
  * @return {Int8Array} List of transactions in the finalized bundle
  */
-export const finalizeBundle = (bundle: Int8Array): Int8Array => {
+export const finalizeBundle = (bundle: Int8Array, numberOfFragments = 3): Int8Array => {
     if (!isMultipleOfTransactionLength(bundle.length)) {
         throw new Error(errors.ILLEGAL_TRANSACTION_BUFFER_LENGTH)
     }
@@ -216,7 +218,7 @@ export const finalizeBundle = (bundle: Int8Array): Int8Array => {
         sponge.squeeze(bundleHash, 0, BUNDLE_LENGTH)
 
         // Stop mutation if essence results to secure bundle.
-        if (normalizedBundle(bundleHash).indexOf(MAX_TRYTE_VALUE /* 13 */) === -1) {
+        if (normalizedBundle(bundleHash).slice(0, numberOfFragments * NORMALIZED_FRAGMENT_LENGTH).indexOf(MAX_TRYTE_VALUE /* 13 */) === -1) {
             // Essence results to secure bundle.
             break
         }


### PR DESCRIPTION
# Description

Adds an argument in `finalizeBundle` to specify which normalized fragments must not contain `13`s. Default value is 3, excluding 13s from all fragments.


## Type of change

- [x] Enhancement (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes