### PR TITLE
Ignore null trytes during trytes to ascii conversion 

### DIFF
--- a/packages/converter/src/ascii.ts
+++ b/packages/converter/src/ascii.ts
@@ -3,26 +3,26 @@ import * as errors from './errors'
 
 /**
  * This method converts ASCII characters to [trytes](https://docs.iota.org/docs/getting-started/0.1/introduction/ternary).
- * 
+ *
  * ## Related methods
- * 
+ *
  * To convert trytes to ASCII characters, use the [`trytesToAscii()`]{@link #module_converter.trytesToAscii} method.
- * 
+ *
  * @method asciiToTrytes
- * 
+ *
  * @summary Converts ASCII characters to trytes.
- *  
+ *
  * @memberof module:converter
  *
  * @param {string} input - ASCII input
- * 
+ *
  * @example
  * ```js
  * let trytes = Converter.asciiToTrytes('Hello, where is my coffee?');
  * ```
- * 
+ *
  * @return {string} Trytes
- * 
+ *
  * @throws {errors.INVALID_ASCII_CHARS}: Make sure that the `input` argument contains only valid ASCII characters.
  */
 export const asciiToTrytes = (input: string): string => {
@@ -45,28 +45,28 @@ export const asciiToTrytes = (input: string): string => {
 
 /**
  * This method converts trytes to ASCII characters.
- * 
+ *
  * Because each ASCII character is represented as 2 trytes, the given trytes must be of an even length.
  *
  * ## Related methods
- * 
+ *
  * To convert ASCII characters to trytes, use the [`asciiToTrytes()`]{@link #module_converter.asciiToTrytes} method.
- * 
+ *
  * @method trytesToAscii
- * 
+ *
  * @summary Converts trytes to ASCII characters.
- *  
+ *
  * @memberof module:converter
  *
  * @param {string} trytes - An even number of trytes
- * 
+ *
  * @example
  * ```js
  * let message = Converter.trytesToAscii('IOTA');
  * ```
- * 
+ *
  * @return {string} ASCII characters
- * 
+ *
  * @throws {errors.INVALID_TRYTES}: Make sure that the `trytes` argument contains only valid trytes (A-Z or 9).
  * @throws {errors.INVALID_ODD_LENGTH}: Make sure that the `trytes` argument contains an even number of trytes.
  */
@@ -82,7 +82,11 @@ export const trytesToAscii = (trytes: string): string => {
     let ascii = ''
 
     for (let i = 0; i < trytes.length; i += 2) {
-        ascii += String.fromCharCode(TRYTE_ALPHABET.indexOf(trytes[i]) + TRYTE_ALPHABET.indexOf(trytes[i + 1]) * 27)
+        const charCode = TRYTE_ALPHABET.indexOf(trytes[i]) + TRYTE_ALPHABET.indexOf(trytes[i + 1]) * 27
+
+        if (charCode) {
+            ascii += String.fromCharCode(charCode)
+        }
     }
 
     return ascii

--- a/packages/converter/test/converter.test.ts
+++ b/packages/converter/test/converter.test.ts
@@ -28,6 +28,13 @@ describe('trytesToAscii(trytes)', async assert => {
     })
 
     assert({
+        given: 'tryte-encoded ascii with 9s',
+        should: 'convert to ascii ignoring zero/null char code',
+        actual: trytesToAscii('SBYBCCKB9999'),
+        expected: 'IOTA',
+    })
+
+    assert({
         given: 'non-trytes',
         should: 'throw error',
         actual: Try(trytesToTrits, 'AAfasds'),


### PR DESCRIPTION
# Description of change

[trytesToAscii()](https://github.com/iotaledger/iota.js/blob/next/packages/converter/src/ascii.ts#L73) converts null trytes to non-breaking whitespaces. This (sometimes) lead to whitespaces at the end of ascii string.

This commit fixes the issue by ignoring null trytes during trytes to ascii conversion.

Fixes https://github.com/iotaledger/iota.js/issues/479

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

- Added unit tests

## Change checklist
- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
