### PR TITLE
Fix imports for multisig package

### DIFF
--- a/packages/multisig/src/address.ts
+++ b/packages/multisig/src/address.ts
@@ -6,7 +6,7 @@ import { asArray } from '../../types'
  * @class Address
  * @memberof module:multisig
  */
-export default class Address {
+export class Address {
     private kerl: Kerl
 
     constructor(digests?: string | ReadonlyArray<string>) {

--- a/packages/multisig/src/multisig.ts
+++ b/packages/multisig/src/multisig.ts
@@ -33,7 +33,7 @@ import {
     Validator,
 } from '../../guards'
 import { Bundle, Callback, Provider, Transaction, Transfer } from '../../types'
-import Address from './address'
+import { Address } from './address'
 
 export { Bundle, Callback, Provider, Transaction, Transfer }
 
@@ -54,7 +54,7 @@ export const multisigInputValidator: Validator<MultisigInput> = (multisigInput: 
 ]
 
 export const sanitizeTransfers = (transfers: ReadonlyArray<Transfer>): ReadonlyArray<Transfer> =>
-    transfers.map(transfer => ({
+    transfers.map((transfer) => ({
         ...transfer,
         message: transfer.message || '',
         tag: transfer.tag || '',
@@ -128,7 +128,7 @@ export const createBundle = (
  *
  * @memberof module:multisig
  */
-export default class Multisig {
+export class Multisig {
     public address = Address
 
     private provider: Provider // tslint:disable-line variable-name
@@ -192,7 +192,7 @@ export default class Multisig {
         kerl.initialize()
 
         // Absorb all key digests
-        digestsArr.forEach(keyDigest => {
+        digestsArr.forEach((keyDigest) => {
             const digestTrits = trytesToTrits(keyDigest)
             kerl.absorb(trytesToTrits(keyDigest), 0, digestTrits.length)
         })

--- a/packages/multisig/src/multisig.ts
+++ b/packages/multisig/src/multisig.ts
@@ -54,7 +54,7 @@ export const multisigInputValidator: Validator<MultisigInput> = (multisigInput: 
 ]
 
 export const sanitizeTransfers = (transfers: ReadonlyArray<Transfer>): ReadonlyArray<Transfer> =>
-    transfers.map((transfer) => ({
+    transfers.map(transfer => ({
         ...transfer,
         message: transfer.message || '',
         tag: transfer.tag || '',
@@ -192,7 +192,7 @@ export class Multisig {
         kerl.initialize()
 
         // Absorb all key digests
-        digestsArr.forEach((keyDigest) => {
+        digestsArr.forEach(keyDigest => {
             const digestTrits = trytesToTrits(keyDigest)
             kerl.absorb(trytesToTrits(keyDigest), 0, digestTrits.length)
         })


### PR DESCRIPTION
# Description of change

Default exports (Multisig & Address) are not properly exported from the multisig package. This commit fixes the problem and ensures all relevant objects are exported from the package.

For instance, the exported object after the fix is:

```
{
  Address: [Function: Address],
  multisigInputValidator: [Function],
  sanitizeTransfers: [Function],
  createBundle: [Function],
  Multisig: [Function: Multisig]
}

```

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Manually tested locally.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
