### PR TITLE
Extend node-fetch polyfill to populate global scope

### DIFF
--- a/packages/iota/es/polyfill-node.js
+++ b/packages/iota/es/polyfill-node.js
@@ -3,7 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Fetch
 if (globalThis && !globalThis.fetch) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    globalThis.fetch = require("node-fetch");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    const fetch = require("node-fetch");
+    globalThis.Headers = fetch.Headers;
+    globalThis.Request = fetch.Request;
+    globalThis.Response = fetch.Response;
+    globalThis.fetch = fetch;
 }
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicG9seWZpbGwtbm9kZS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uL3NyYy9wb2x5ZmlsbC1ub2RlLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7QUFBQSwrQkFBK0I7QUFDL0Isc0NBQXNDO0FBRXRDLFFBQVE7QUFDUixJQUFJLFVBQVUsSUFBSSxDQUFDLFVBQVUsQ0FBQyxLQUFLLEVBQUU7SUFDakMsaUVBQWlFO0lBQ2pFLFVBQVUsQ0FBQyxLQUFLLEdBQUcsT0FBTyxDQUFDLFlBQVksQ0FBQyxDQUFDO0NBQzVDIn0=
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicG9seWZpbGwtbm9kZS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uL3NyYy9wb2x5ZmlsbC1ub2RlLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7QUFBQSwrQkFBK0I7QUFDL0Isc0NBQXNDO0FBRXRDLFFBQVE7QUFDUixJQUFJLFVBQVUsSUFBSSxDQUFDLFVBQVUsQ0FBQyxLQUFLLEVBQUU7SUFDakMscUdBQXFHO0lBQ3JHLE1BQU0sS0FBSyxHQUFHLE9BQU8sQ0FBQyxZQUFZLENBQUMsQ0FBQztJQUNwQyxVQUFVLENBQUMsT0FBTyxHQUFHLEtBQUssQ0FBQyxPQUFPLENBQUM7SUFDbkMsVUFBVSxDQUFDLE9BQU8sR0FBRyxLQUFLLENBQUMsT0FBTyxDQUFDO0lBQ25DLFVBQVUsQ0FBQyxRQUFRLEdBQUcsS0FBSyxDQUFDLFFBQVEsQ0FBQztJQUNyQyxVQUFVLENBQUMsS0FBSyxHQUFHLEtBQUssQ0FBQztDQUM1QiJ9

--- a/packages/iota/src/polyfill-node.ts
+++ b/packages/iota/src/polyfill-node.ts
@@ -4,5 +4,9 @@
 // Fetch
 if (globalThis && !globalThis.fetch) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    globalThis.fetch = require("node-fetch");
+    const fetch = require('node-fetch');
+    globalThis.Headers = fetch.Headers;
+    globalThis.Request = fetch.Request;
+    globalThis.Response = fetch.Response;
+    globalThis.fetch = fetch;
 }

--- a/packages/iota/src/polyfill-node.ts
+++ b/packages/iota/src/polyfill-node.ts
@@ -3,8 +3,8 @@
 
 // Fetch
 if (globalThis && !globalThis.fetch) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const fetch = require('node-fetch');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    const fetch = require("node-fetch");
     globalThis.Headers = fetch.Headers;
     globalThis.Request = fetch.Request;
     globalThis.Response = fetch.Response;


### PR DESCRIPTION
# Description of change

Extend the node-fetch polyfill to also populate `Headers`, `Request`, and `Response` in the global scope. The implementation of identity-wasm (dictated by https://docs.rs/reqwest/latest/reqwest/) relies on those features. In projects where both libraries are included the previous "incomplete" polyfill breaks identity-wasm.    

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
